### PR TITLE
Simplify Movement Logic

### DIFF
--- a/imgui.ini
+++ b/imgui.ini
@@ -9,7 +9,7 @@ Size=476,528
 Collapsed=1
 
 [Window][Editor]
-Pos=849,121
+Pos=832,123
 Size=316,475
 Collapsed=0
 

--- a/src/pixel.cpp
+++ b/src/pixel.cpp
@@ -33,7 +33,6 @@ auto properties(const pixel& pix) -> const pixel_properties&
                 .can_move_diagonally = true,
                 .gravity_factor = 1.0f,
                 .inertial_resistance = 0.1f,
-                .horizontal_transfer = 0.3f,
                 .corrosion_resist = 0.3f
             };
             return px;
@@ -43,7 +42,6 @@ auto properties(const pixel& pix) -> const pixel_properties&
                 .can_move_diagonally = true,
                 .gravity_factor = 1.0f,
                 .inertial_resistance = 0.4f,
-                .horizontal_transfer = 0.2f,
                 .corrosion_resist = 0.5f
             };
             return px;
@@ -53,7 +51,6 @@ auto properties(const pixel& pix) -> const pixel_properties&
                 .can_move_diagonally = true,
                 .gravity_factor = 1.0f,
                 .inertial_resistance = 0.95f,
-                .horizontal_transfer = 0.1f,
                 .corrosion_resist = 0.8f,
                 .flammability = 0.02f,
                 .put_out_surrounded = 0.15f,
@@ -160,7 +157,6 @@ auto properties(const pixel& pix) -> const pixel_properties&
                 .can_move_diagonally = true,
                 .gravity_factor = 1.0f,
                 .inertial_resistance = 0.1f,
-                .horizontal_transfer = 0.4f,
                 .corrosion_resist = 0.1f,
                 .flammability = 0.25f,
                 .put_out_surrounded = 0.0f,

--- a/src/pixel.hpp
+++ b/src/pixel.hpp
@@ -46,7 +46,6 @@ struct pixel_properties
     bool        can_move_diagonally = false;
     float       gravity_factor      = 0.0f;
     float       inertial_resistance = 0.0f;
-    float       horizontal_transfer = 0.0f;
     int         dispersion_rate     = 0;
 
     // Water Controls

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -119,9 +119,10 @@ inline auto update_pixel_position(world& pixels, glm::ivec2& pos) -> void
 {
     auto& data = pixels.at(pos);
     const auto& props = properties(data);
+    const auto start_pos = pos;
 
     // Pixels that don't move have their is_falling flag set to false at the end
-    const auto after_position_update = scope_exit{[&, start_pos = pos] {
+    const auto after_position_update = scope_exit{[&] {
         pixels.at(pos).flags[is_falling] = pos != start_pos;
     }};
 
@@ -146,18 +147,6 @@ inline auto update_pixel_position(world& pixels, glm::ivec2& pos) -> void
         for (auto offset : offsets) {
             if (move_offset(pixels, pos, offset)) return;
         }
-    }
-
-    // Transfer to horizontal
-    if (props.horizontal_transfer) {
-        auto& data = pixels.at(pos);
-        auto& vel = data.velocity;
-        if (vel.y > 5.0 && vel.x == 0.0) {
-            const auto ht = properties(data).horizontal_transfer;
-            vel.x = random_from_range(std::max(0.0f, ht - 0.1f), std::min(1.0f, ht + 0.1f)) * vel.y * sign_flip();
-            vel.y = 0.0;
-        }
-        vel.x *= 0.8;
     }
 
     // Attempts to disperse outwards according to the dispersion rate


### PR DESCRIPTION
* Horizontal transfer was implemented wrong, and I didn't like how it would launch pixels sideways when dropping lots of pixels.
* Will rework the movement logic at some point to be better.