### PR TITLE
Smooth Camera Movement

### DIFF
--- a/imgui.ini
+++ b/imgui.ini
@@ -9,7 +9,7 @@ Size=476,528
 Collapsed=1
 
 [Window][Editor]
-Pos=1435,57
-Size=296,752
+Pos=889,59
+Size=373,614
 Collapsed=0
 

--- a/imgui.ini
+++ b/imgui.ini
@@ -4,12 +4,12 @@ Size=400,400
 Collapsed=0
 
 [Window][Dear ImGui Demo]
-Pos=738,39
+Pos=305,39
 Size=476,528
 Collapsed=1
 
 [Window][Editor]
-Pos=912,82
-Size=331,628
+Pos=1435,57
+Size=296,752
 Collapsed=0
 

--- a/imgui.ini
+++ b/imgui.ini
@@ -9,7 +9,7 @@ Size=476,528
 Collapsed=1
 
 [Window][Editor]
-Pos=889,59
+Pos=888,60
 Size=373,614
 Collapsed=0
 

--- a/imgui.ini
+++ b/imgui.ini
@@ -4,7 +4,7 @@ Size=400,400
 Collapsed=0
 
 [Window][Dear ImGui Demo]
-Pos=305,39
+Pos=717,15
 Size=476,528
 Collapsed=1
 

--- a/src/camera.hpp
+++ b/src/camera.hpp
@@ -8,7 +8,8 @@ struct camera
     glm::vec2 top_left;
     std::uint32_t       screen_width;
     std::uint32_t       screen_height;
-    int       zoom;
+
+    float world_to_screen; // the number of screen pixels per world pixel, multiplying by it takes you from world space to screen space
 };
 
 }

--- a/src/camera.hpp
+++ b/src/camera.hpp
@@ -6,8 +6,8 @@ namespace sand {
 struct camera
 {
     glm::vec2 top_left;
-    float     screen_width;
-    float     screen_height;
+    std::uint32_t       screen_width;
+    std::uint32_t       screen_height;
     int       zoom;
 };
 

--- a/src/camera.hpp
+++ b/src/camera.hpp
@@ -6,9 +6,8 @@ namespace sand {
 struct camera
 {
     glm::vec2 top_left;
-    std::uint32_t       screen_width;
-    std::uint32_t       screen_height;
-
+    float screen_width;
+    float screen_height;
     float world_to_screen; // the number of screen pixels per world pixel, multiplying by it takes you from world space to screen space
 };
 

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -58,11 +58,8 @@ auto display_ui(
         if (ImGui::RadioButton("Square", editor.brush_type == 1)) {
             editor.brush_type = 1;
         }
-        if (ImGui::RadioButton("Fine", editor.brush_type == 2)) {
+        if (ImGui::RadioButton("Explosion", editor.brush_type == 2)) {
             editor.brush_type = 2;
-        }
-        if (ImGui::RadioButton("Explosion", editor.brush_type == 3)) {
-            editor.brush_type = 3;
         }
         ImGui::Text("Brush: %d", editor.brush_type);
 

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -44,8 +44,7 @@ struct editor
     std::size_t brush_type = 1;
         // 0 == circular spray
         // 1 == square
-        // 2 == fine
-        // 3 == explosion
+        // 2 == explosion
         
     bool show_chunks = false;
     bool show_demo = true;

--- a/src/event.hpp
+++ b/src/event.hpp
@@ -47,16 +47,12 @@ struct mouse_released_event {
 };
 
 struct mouse_moved_event {
-	double x_pos;
-	double y_pos;
-
-	double x_offset;
-	double y_offset;
+	glm::vec2 pos;
+	glm::vec2 offset;
 };
 
 struct mouse_scrolled_event {
-	double x_offset;
-	double y_offset;
+	glm::vec2 offset;
 };
 
 // WINDOW EVENTS

--- a/src/graphics/renderer.cpp
+++ b/src/graphics/renderer.cpp
@@ -100,14 +100,11 @@ renderer::~renderer()
 auto renderer::update(const world& world, bool show_chunks, const camera& camera) -> void
 {
     static const auto fire_colours = std::array{
-        sand::from_hex(0xe55039),
-        sand::from_hex(0xf6b93b),
-        sand::from_hex(0xfad390)
+        from_hex(0xe55039), from_hex(0xf6b93b), from_hex(0xfad390)
     };
 
     static const auto electricity_colours = std::array{
-        sand::from_hex(0xf6e58d),
-        sand::from_hex(0xf9ca24)
+        from_hex(0xf6e58d), from_hex(0xf9ca24)
     };
 
     const auto tex_top_left = glm::ivec2{glm::floor(camera.top_left)};
@@ -123,7 +120,7 @@ auto renderer::update(const world& world, bool show_chunks, const camera& camera
     d_shader.load_vec2("u_tex_offset", tex_offset);
     d_shader.load_vec2("u_tex_dimensions", glm::vec2{tex_width, tex_height});
 
-    const auto projection = glm::ortho(0.0f, (float)camera.screen_width, (float)camera.screen_height, 0.0f);
+    const auto projection = glm::ortho(0.0f, camera.screen_width, camera.screen_height, 0.0f);
     d_shader.load_mat4("u_proj_matrix", projection);
 
     for (std::size_t x = 0; x != d_texture.width(); ++x) {

--- a/src/graphics/renderer.cpp
+++ b/src/graphics/renderer.cpp
@@ -118,27 +118,23 @@ auto renderer::update(const world& world, bool show_chunks, const camera& camera
         sand::from_hex(0xf9ca24)
     };
 
-    const auto aspect_ratio = static_cast<float>(camera.screen_width) / camera.screen_height;
-
     const auto camera_top_left = glm::ivec2{glm::floor(camera.top_left)};
 
     const auto camera_width = static_cast<int>(
-        ((float)camera.screen_height/camera.world_to_screen) * aspect_ratio
+        (float)camera.screen_width/camera.world_to_screen
     ) + 2;
     const auto camera_height = static_cast<int>(
         (float)camera.screen_height/camera.world_to_screen
     ) + 2;
 
-    const auto scale_factor = (float)camera.screen_height / ((float)camera.screen_height/camera.world_to_screen);
-
     if (d_texture.width() != camera_width || d_texture.height() != camera_height) {
         resize(camera_width, camera_height);
     }
 
-    d_shader.load_float("u_width_offset",  scale_factor * (camera.top_left.x - camera_top_left.x));
-    d_shader.load_float("u_height_offset", scale_factor * (camera.top_left.y - camera_top_left.y));
-    d_shader.load_int("u_screen_width",  scale_factor * camera_width);
-    d_shader.load_int("u_screen_height", scale_factor * camera_height);
+    d_shader.load_float("u_width_offset",  camera.world_to_screen * (camera.top_left.x - camera_top_left.x));
+    d_shader.load_float("u_height_offset", camera.world_to_screen * (camera.top_left.y - camera_top_left.y));
+    d_shader.load_int("u_screen_width",    camera.world_to_screen * camera_width);
+    d_shader.load_int("u_screen_height",   camera.world_to_screen * camera_height);
 
     const auto projection = glm::ortho(0.0f, (float)camera.screen_width, (float)camera.screen_height, 0.0f);
     d_shader.load_mat4("u_proj_matrix", projection);

--- a/src/graphics/renderer.cpp
+++ b/src/graphics/renderer.cpp
@@ -125,8 +125,8 @@ auto renderer::update(const world& world, bool show_chunks, const camera& camera
     };
 
 
-    const auto camera_width = static_cast<int>(camera.zoom * aspect_ratio) + 2;
-    const auto camera_height = static_cast<int>(camera.zoom) + 2;
+    const auto camera_width = static_cast<int>(std::ceil(camera.zoom * aspect_ratio)) + 1;
+    const auto camera_height = static_cast<int>(std::ceil(camera.zoom)) + 1;
 
     const auto scale_factor = (float)camera.screen_height / camera.zoom;
 

--- a/src/graphics/renderer.cpp
+++ b/src/graphics/renderer.cpp
@@ -14,12 +14,16 @@ constexpr auto vertex_shader = R"SHADER(
 layout (location = 0) in vec4 position_uv;
 
 uniform mat4 u_proj_matrix;
+uniform int  u_screen_width;
+uniform int  u_screen_height;
 
 out vec2 pass_uv;
 
 void main()
 {
     vec2 position = position_uv.xy;
+    position.x = position.x * u_screen_width;
+    position.y = position.y * u_screen_height;
     pass_uv = position_uv.zw;
     gl_Position = u_proj_matrix * vec4(position, 0, 1);
 }
@@ -112,12 +116,18 @@ auto renderer::update(const world& world, bool show_chunks, const camera& camera
         sand::from_hex(0xf9ca24)
     };
 
-    const auto camera_width = camera.zoom * (camera.screen_width / camera.screen_height);
+    const auto camera_width = camera.zoom * ((float)camera.screen_width / camera.screen_height);
     const auto camera_height = camera.zoom;
 
     if (d_texture.width() != camera_width || d_texture.height() != camera_height) {
         resize(camera_width, camera_height);
     }
+
+    d_shader.load_int("u_screen_width", camera.screen_width);
+    d_shader.load_int("u_screen_height", camera.screen_height);
+
+    const auto projection = glm::ortho(0.0f, (float)camera.screen_width, (float)camera.screen_height, 0.0f);
+    d_shader.load_mat4("u_proj_matrix", projection);
 
     for (std::size_t x = 0; x != d_texture.width(); ++x) {
         for (std::size_t y = 0; y != d_texture.height(); ++y) {

--- a/src/graphics/renderer.cpp
+++ b/src/graphics/renderer.cpp
@@ -118,23 +118,19 @@ auto renderer::update(const world& world, bool show_chunks, const camera& camera
         sand::from_hex(0xf9ca24)
     };
 
-    const auto camera_top_left = glm::ivec2{glm::floor(camera.top_left)};
+    const auto tex_top_left = glm::ivec2{glm::floor(camera.top_left)};
+    const auto tex_offset = camera.top_left - glm::vec2{tex_top_left};
+    const auto tex_width = std::ceil(camera.screen_width / camera.world_to_screen + 1);
+    const auto tex_height = std::ceil(camera.screen_height / camera.world_to_screen + 1);
 
-    const auto camera_width = static_cast<int>(
-        (float)camera.screen_width/camera.world_to_screen
-    ) + 2;
-    const auto camera_height = static_cast<int>(
-        (float)camera.screen_height/camera.world_to_screen
-    ) + 2;
-
-    if (d_texture.width() != camera_width || d_texture.height() != camera_height) {
-        resize(camera_width, camera_height);
+    if (d_texture.width() != tex_width || d_texture.height() != tex_height) {
+        resize(tex_width, tex_height);
     }
 
-    d_shader.load_float("u_width_offset",  camera.world_to_screen * (camera.top_left.x - camera_top_left.x));
-    d_shader.load_float("u_height_offset", camera.world_to_screen * (camera.top_left.y - camera_top_left.y));
-    d_shader.load_int("u_screen_width",    camera.world_to_screen * camera_width);
-    d_shader.load_int("u_screen_height",   camera.world_to_screen * camera_height);
+    d_shader.load_float("u_width_offset",  camera.world_to_screen * tex_offset.x);
+    d_shader.load_float("u_height_offset", camera.world_to_screen * tex_offset.y);
+    d_shader.load_int("u_screen_width",    camera.world_to_screen * tex_width);
+    d_shader.load_int("u_screen_height",   camera.world_to_screen * tex_height);
 
     const auto projection = glm::ortho(0.0f, (float)camera.screen_width, (float)camera.screen_height, 0.0f);
     d_shader.load_mat4("u_proj_matrix", projection);
@@ -142,7 +138,7 @@ auto renderer::update(const world& world, bool show_chunks, const camera& camera
     for (std::size_t x = 0; x != d_texture.width(); ++x) {
         for (std::size_t y = 0; y != d_texture.height(); ++y) {
             const auto screen_coord = glm::ivec2{x, y};
-            const auto world_coord = camera_top_left + screen_coord;
+            const auto world_coord = tex_top_left + screen_coord;
             const auto pos = x + d_texture.width() * y;
             if (!world.valid(world_coord)) {
                 d_texture_data[pos] = glm::vec4{1.0, 1.0, 1.0, 1.0};

--- a/src/graphics/renderer.cpp
+++ b/src/graphics/renderer.cpp
@@ -126,10 +126,10 @@ auto renderer::update(const world& world, bool show_chunks, const camera& camera
     };
 
 
-    const auto camera_width = static_cast<int>(camera.zoom * aspect_ratio + 1);
-    const auto camera_height = static_cast<int>(camera.zoom + 1);
+    const auto camera_width = static_cast<int>(camera.zoom * aspect_ratio + 2);
+    const auto camera_height = static_cast<int>(camera.zoom + 2);
 
-    const auto scale_factor = (float)camera.screen_width / (camera.zoom * (static_cast<float>(camera.screen_width) / camera.screen_height));
+    const auto scale_factor = (float)camera.screen_height / camera.zoom;
 
     if (d_texture.width() != camera_width || d_texture.height() != camera_height) {
         resize(camera_width, camera_height);
@@ -138,8 +138,8 @@ auto renderer::update(const world& world, bool show_chunks, const camera& camera
     d_shader.load_vec2("u_top_left", camera.top_left);
     d_shader.load_float("u_width_offset",  scale_factor * (camera.top_left.x - camera_top_left.x));
     d_shader.load_float("u_height_offset", scale_factor * (camera.top_left.y - camera_top_left.y));
-    d_shader.load_int("u_screen_width", camera.screen_width);
-    d_shader.load_int("u_screen_height", camera.screen_height);
+    d_shader.load_int("u_screen_width",  scale_factor * camera_width);
+    d_shader.load_int("u_screen_height", scale_factor * camera_height);
 
     const auto projection = glm::ortho(0.0f, (float)camera.screen_width, (float)camera.screen_height, 0.0f);
     d_shader.load_mat4("u_proj_matrix", projection);

--- a/src/graphics/renderer.cpp
+++ b/src/graphics/renderer.cpp
@@ -125,10 +125,14 @@ auto renderer::update(const world& world, bool show_chunks, const camera& camera
     };
 
 
-    const auto camera_width = static_cast<int>(std::ceil(camera.zoom * aspect_ratio)) + 1;
-    const auto camera_height = static_cast<int>(std::ceil(camera.zoom)) + 1;
+    const auto camera_width = static_cast<int>(
+        ((float)camera.screen_height/camera.world_to_screen) * aspect_ratio
+    ) + 2;
+    const auto camera_height = static_cast<int>(
+        (float)camera.screen_height/camera.world_to_screen
+    ) + 2;
 
-    const auto scale_factor = (float)camera.screen_height / camera.zoom;
+    const auto scale_factor = (float)camera.screen_height / ((float)camera.screen_height/camera.world_to_screen);
 
     if (d_texture.width() != camera_width || d_texture.height() != camera_height) {
         resize(camera_width, camera_height);

--- a/src/graphics/renderer.cpp
+++ b/src/graphics/renderer.cpp
@@ -125,37 +125,37 @@ auto renderer::update(const world& world, bool show_chunks, const camera& camera
 
     for (std::size_t x = 0; x != d_texture.width(); ++x) {
         for (std::size_t y = 0; y != d_texture.height(); ++y) {
-            const auto screen_coord = glm::ivec2{x, y};
-            const auto world_coord = tex_top_left + screen_coord;
-            const auto pos = x + d_texture.width() * y;
+            const auto world_coord = tex_top_left + glm::ivec2{x, y};
+            auto& colour = d_texture_data[x + d_texture.width() * y];
+
             if (!world.valid(world_coord)) {
-                d_texture_data[pos] = glm::vec4{1.0, 1.0, 1.0, 1.0};
+                colour = glm::vec4{1.0, 1.0, 1.0, 1.0};
                 continue;
             }
             const auto& pixel = world.at(world_coord);
             const auto& props = properties(pixel);
 
             if (pixel.flags[is_burning]) {
-                d_texture_data[pos] = light_noise(sand::random_element(fire_colours));
+                colour = sand::random_element(fire_colours);
             }
             else if (props.power_type == pixel_power_type::source) {
                 const auto a = from_hex(0x000000); // black
                 const auto b = pixel.colour;
                 const auto t = (float)pixel.power / props.power_max;
-                d_texture_data[pos] = sand::lerp(a, b, t);
+                colour = sand::lerp(a, b, t);
             }
             else if (props.power_type == pixel_power_type::conductor) {
                 const auto a = pixel.colour;
                 const auto b = sand::random_element(electricity_colours);
                 const auto t = (float)pixel.power / props.power_max;
-                d_texture_data[pos] = sand::lerp(a, b, t);
+                colour = sand::lerp(a, b, t);
             }
             else {
-                d_texture_data[pos] = pixel.colour;
+                colour = pixel.colour;
             }
 
             if (show_chunks && world.is_chunk_awake(world_coord)) {
-                d_texture_data[pos] += glm::vec4{0.05, 0.05, 0.05, 0};
+                colour += glm::vec4{0.05, 0.05, 0.05, 0};
             }
         }
     }

--- a/src/graphics/renderer.cpp
+++ b/src/graphics/renderer.cpp
@@ -19,7 +19,7 @@ uniform int  u_screen_width;
 uniform int  u_screen_height;
 
 uniform float u_width_offset;
-uniform float u_height offset;
+uniform float u_height_offset;
 
 out vec2 pass_uv;
 
@@ -125,16 +125,19 @@ auto renderer::update(const world& world, bool show_chunks, const camera& camera
         std::floor(camera.top_left.x), std::floor(camera.top_left.y)
     };
 
+
     const auto camera_width = static_cast<int>(camera.zoom * aspect_ratio + 1);
     const auto camera_height = static_cast<int>(camera.zoom + 1);
+
+    const auto scale_factor = (float)camera.screen_width / (camera.zoom * (static_cast<float>(camera.screen_width) / camera.screen_height));
 
     if (d_texture.width() != camera_width || d_texture.height() != camera_height) {
         resize(camera_width, camera_height);
     }
 
     d_shader.load_vec2("u_top_left", camera.top_left);
-    d_shader.load_float("u_width_offset", camera.top_left.x - camera_top_left.x);
-    d_shader.load_float("u_height_offset", camera.top_left.y - camera_top_left.y);
+    d_shader.load_float("u_width_offset",  scale_factor * (camera.top_left.x - camera_top_left.x));
+    d_shader.load_float("u_height_offset", scale_factor * (camera.top_left.y - camera_top_left.y));
     d_shader.load_int("u_screen_width", camera.screen_width);
     d_shader.load_int("u_screen_height", camera.screen_height);
 
@@ -144,7 +147,7 @@ auto renderer::update(const world& world, bool show_chunks, const camera& camera
     for (std::size_t x = 0; x != d_texture.width(); ++x) {
         for (std::size_t y = 0; y != d_texture.height(); ++y) {
             const auto screen_coord = glm::ivec2{x, y};
-            const auto world_coord = glm::ivec2{camera.top_left} + screen_coord;
+            const auto world_coord = camera_top_left + screen_coord;
             const auto pos = x + d_texture.width() * y;
             if (!world.valid(world_coord)) {
                 d_texture_data[pos] = glm::vec4{1.0, 1.0, 1.0, 1.0};

--- a/src/graphics/renderer.cpp
+++ b/src/graphics/renderer.cpp
@@ -141,13 +141,13 @@ auto renderer::update(const world& world, bool show_chunks, const camera& camera
             else if (props.power_type == pixel_power_type::source) {
                 const auto a = from_hex(0x000000); // black
                 const auto b = pixel.colour;
-                const auto t = (float)pixel.power / props.power_max;
+                const auto t = static_cast<float>(pixel.power) / props.power_max;
                 colour = sand::lerp(a, b, t);
             }
             else if (props.power_type == pixel_power_type::conductor) {
                 const auto a = pixel.colour;
                 const auto b = sand::random_element(electricity_colours);
-                const auto t = (float)pixel.power / props.power_max;
+                const auto t = static_cast<float>(pixel.power) / props.power_max;
                 colour = sand::lerp(a, b, t);
             }
             else {

--- a/src/graphics/renderer.cpp
+++ b/src/graphics/renderer.cpp
@@ -120,10 +120,7 @@ auto renderer::update(const world& world, bool show_chunks, const camera& camera
 
     const auto aspect_ratio = static_cast<float>(camera.screen_width) / camera.screen_height;
 
-    const auto camera_top_left = glm::ivec2{
-        std::floor(camera.top_left.x), std::floor(camera.top_left.y)
-    };
-
+    const auto camera_top_left = glm::ivec2{glm::floor(camera.top_left)};
 
     const auto camera_width = static_cast<int>(
         ((float)camera.screen_height/camera.world_to_screen) * aspect_ratio

--- a/src/graphics/renderer.cpp
+++ b/src/graphics/renderer.cpp
@@ -14,7 +14,6 @@ constexpr auto vertex_shader = R"SHADER(
 layout (location = 0) in vec4 position_uv;
 
 uniform mat4 u_proj_matrix;
-uniform vec2 u_top_left;
 uniform int  u_screen_width;
 uniform int  u_screen_height;
 
@@ -126,8 +125,8 @@ auto renderer::update(const world& world, bool show_chunks, const camera& camera
     };
 
 
-    const auto camera_width = static_cast<int>(camera.zoom * aspect_ratio + 2);
-    const auto camera_height = static_cast<int>(camera.zoom + 2);
+    const auto camera_width = static_cast<int>(camera.zoom * aspect_ratio) + 2;
+    const auto camera_height = static_cast<int>(camera.zoom) + 2;
 
     const auto scale_factor = (float)camera.screen_height / camera.zoom;
 
@@ -135,7 +134,6 @@ auto renderer::update(const world& world, bool show_chunks, const camera& camera
         resize(camera_width, camera_height);
     }
 
-    d_shader.load_vec2("u_top_left", camera.top_left);
     d_shader.load_float("u_width_offset",  scale_factor * (camera.top_left.x - camera_top_left.x));
     d_shader.load_float("u_height_offset", scale_factor * (camera.top_left.y - camera_top_left.y));
     d_shader.load_int("u_screen_width",  scale_factor * camera_width);

--- a/src/graphics/shader.cpp
+++ b/src/graphics/shader.cpp
@@ -83,6 +83,11 @@ auto shader::load_mat4(const std::string& name, const glm::mat4& matrix) const -
     glUniformMatrix4fv(get_location(name), 1, GL_FALSE, glm::value_ptr(matrix));
 }
 
+auto shader::load_vec2(const std::string& name, const glm::vec2& vector) const -> void
+{
+	glUniform2f(get_location(name), vector.x, vector.y);
+}
+
 auto shader::load_sampler(const std::string& name, int value) const -> void
 {
 	glProgramUniform1i(d_program, get_location(name), value);
@@ -91,6 +96,11 @@ auto shader::load_sampler(const std::string& name, int value) const -> void
 auto shader::load_int(const std::string& name, int value) const -> void
 {
 	glProgramUniform1i(d_program, get_location(name), value);
+}
+
+auto shader::load_float(const std::string& name, float value) const -> void
+{
+	glUniform1f(get_location(name), value);
 }
 
 }

--- a/src/graphics/shader.hpp
+++ b/src/graphics/shader.hpp
@@ -28,7 +28,9 @@ public:
     auto unbind() const -> void;
 
     auto load_mat4(const std::string& name, const glm::mat4& matrix) const -> void;
+    auto load_vec2(const std::string& name, const glm::vec2& vector) const -> void;
     auto load_int(const std::string& name, int value) const -> void;
+    auto load_float(const std::string& name, float value) const -> void;
     auto load_sampler(const std::string& name, int value) const -> void;
 };
 

--- a/src/graphics/window.cpp
+++ b/src/graphics/window.cpp
@@ -124,7 +124,7 @@ window::window(const std::string& name, int width, int height)
 		auto& data = get_window_data(window);
 		if (!data.focused) return;
 		auto event = make_event<mouse_moved_event>(
-			x_pos, y_pos, x_pos - data.mouse_pos.x, y_pos - data.mouse_pos.y
+			glm::vec2{x_pos, y_pos}, glm::vec2{x_pos - data.mouse_pos.x, y_pos - data.mouse_pos.y}
 		);
 		data.mouse_pos = {x_pos, y_pos};
 		data.callback(event);
@@ -133,7 +133,7 @@ window::window(const std::string& name, int width, int height)
 	glfwSetScrollCallback(native_window, [](GLFWwindow* window, double x_offset, double y_offset) {
 		auto& data = get_window_data(window);
 		if (!data.focused) return;
-		auto event = make_event<mouse_scrolled_event>(x_offset, y_offset);
+		auto event = make_event<mouse_scrolled_event>(glm::vec2{x_offset, y_offset});
 		data.callback(event);
 	});
 

--- a/src/graphics/window.cpp
+++ b/src/graphics/window.cpp
@@ -213,12 +213,12 @@ void window::set_callback(const window_callback& callback)
     d_data.callback = callback;
 }
 
-auto window::width() const -> std::uint32_t
+auto window::width() const -> int
 {
 	return d_data.width; 
 }
 
-auto window::height() const -> std::uint32_t
+auto window::height() const -> int
 {
 	return d_data.height; 
 }

--- a/src/graphics/window.hpp
+++ b/src/graphics/window.hpp
@@ -55,8 +55,8 @@ public:
     auto set_name(const std::string& name) -> void;
     auto set_callback(const window_callback& callback) -> void;
 
-    auto width() const -> std::uint32_t;
-    auto height() const -> std::uint32_t;
+    auto width() const -> int;
+    auto height() const -> int;
 
     auto native_handle() -> GLFWwindow*;
 };

--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -33,8 +33,8 @@ auto main() -> int
 
     auto camera = sand::camera{
         .top_left = {0, 0},
-        .screen_width = static_cast<float>(window.width()),
-        .screen_height = static_cast<float>(window.height()),
+        .screen_width = window.width(),
+        .screen_height = window.height(),
         .zoom = 256
     };
 

--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -54,7 +54,6 @@ auto main() -> int
 
         if (mouse.is_button_down(sand::mouse_button::right) && event.is<sand::mouse_moved_event>()) {
             const auto& e = event.as<sand::mouse_moved_event>();
-            // Diving by world_to_screen takes you from screen space to world space
             camera.top_left -= e.offset / camera.world_to_screen;
         }
         else if (event.is<sand::window_resize_event>()) {

--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -116,7 +116,7 @@ auto main() -> int
                 if (mouse.is_button_down(sand::mouse_button::left)) {
                     const auto half_extent = (int)(editor.brush_size / 2);
                     for (int x = mouse_pos.x - half_extent; x != mouse_pos.x + half_extent + 1; ++x) {
-                        for (int y = mouse_pos.y - half_extent; y != mouse_pos.y + half_extent; ++y) {
+                        for (int y = mouse_pos.y - half_extent; y != mouse_pos.y + half_extent + 1; ++y) {
                             if (world->valid({x, y})) {
                                 world->set({x, y}, editor.get_pixel());
                             }

--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -36,8 +36,8 @@ auto main() -> int
 
     auto camera = sand::camera{
         .top_left = {0, 0},
-        .screen_width = window.width(),
-        .screen_height = window.height(),
+        .screen_width = (float)window.width(),
+        .screen_height = (float)window.height(),
         .world_to_screen = 720.0f / 256.0f
     };
 

--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -36,8 +36,8 @@ auto main() -> int
 
     auto camera = sand::camera{
         .top_left = {0, 0},
-        .screen_width = (float)window.width(),
-        .screen_height = (float)window.height(),
+        .screen_width = static_cast<float>(window.width()),
+        .screen_height = static_cast<float>(window.height()),
         .world_to_screen = 720.0f / 256.0f
     };
 
@@ -121,12 +121,6 @@ auto main() -> int
                                 world->set({x, y}, editor.get_pixel());
                             }
                         }
-                    }
-                }
-            break; case 2:
-                if (mouse.is_button_down(sand::mouse_button::left)) {
-                    if (world->valid(mouse_pos)) {
-                        world->set(mouse_pos, editor.get_pixel());
                     }
                 }
             break; case 3:


### PR DESCRIPTION
* Scrolling and zooming the camera is no longer fixed to the pixel grid, allowing for smooth camera movement. This is achieved by storing the offset of the position from the grid, and using that to offset the texture in the vertex shader. The texture needs to be one pixel larger to allow for the offset.
* Rather than storing the number of pixels we want to make up the height, the `camera` struct instead stores the number of screen pixels we want per world pixel, which is stored as a float to allow for smooth zooming.
* `window::width()` and `window::height()` now return ints to reduce casting. The original values from glfw were ints anyway.
* Remove the "fine" tool since the square brush is now a minimum of one pixel in size.
* `mouse_moved_event` and `mouse_scrolled_event` now use `glm::vec` instead of pairs of floats.