### PR TITLE
Multiple Obstacles

### DIFF
--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -126,7 +126,7 @@ class static_physics_box
     b2Body*   d_body = nullptr;
 
 public:
-    static_physics_box(b2World& world, glm::vec2 pos, int width, int height, glm::vec3 colour)
+    static_physics_box(b2World& world, glm::vec2 pos, int width, int height, glm::vec3 colour, float angle = 0.0f)
         : d_width{width}
         , d_height{height}
         , d_colour{colour}
@@ -135,6 +135,7 @@ public:
         bodyDef.type = b2_staticBody;
         const auto position = pixel_to_physics(pos);
         bodyDef.position.Set(position.x, position.y);
+        bodyDef.angle = angle;
         d_body = world.CreateBody(&bodyDef);
 
         b2PolygonShape box;
@@ -217,14 +218,11 @@ auto main() -> int
     auto timer           = sand::timer{};
     auto player_renderer = sand::player_renderer{};
     auto player          = player_controller(physics, 10, 20);
-    
-    auto floor = static_physics_box(physics, {128, 256 + 5}, 256, 10, {1.0, 1.0, 0.0});
-    auto box = static_physics_box(physics, {64, 256 + 5}, 30, 50, {1.0, 1.0, 0.0});
 
     auto ground = std::vector<static_physics_box>{
         {physics, {128, 256 + 5}, 256, 10, {1.0, 1.0, 0.0}},
         {physics, {64, 256 + 5}, 30, 50, {1.0, 1.0, 0.0}},
-        {physics, {130, 215}, 30, 10, {1.0, 1.0, 0.0}}
+        {physics, {130, 215}, 30, 10, {1.0, 1.0, 0.0}, 1.5f}
     };
 
     while (window.is_running()) {


### PR DESCRIPTION
* Vastly simplify the player code; it doesn't need to be a contact listener since you can query what objects are touching the player directly, and it's more efficient.
* Add `static_physics_box` which represents a solid box.
* Replace the floor edge and hacky rendering with a box, and add a few more as obstacles to jump on.
* The player is now made up of two fixtures, with one being slightly shorter and wider with 0 friction, which makes it impossible to cling to the sides of walls. There must be a better way, possibly only adding friction when on the floor?