### PR TITLE
Update World via Chunks

### DIFF
--- a/imgui.ini
+++ b/imgui.ini
@@ -9,7 +9,7 @@ Size=476,528
 Collapsed=1
 
 [Window][Editor]
-Pos=918,96
+Pos=832,71
 Size=408,604
 Collapsed=0
 

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -374,9 +374,11 @@ auto update(world& w) -> void
         pixel.flags[is_updated] = false;
     }
 
-    for (std::size_t index = 0; index != w.chunks.size(); ++index) {
-        if (!w.chunks[index].should_step) continue;
-
+    for (auto it = w.chunks.rbegin(); it != w.chunks.rend(); ++it) {
+        auto& chunk = *it;
+        if (!chunk.should_step) continue;
+    
+        const auto index = w.chunks.size() - std::distance(w.chunks.rbegin(), it) - 1;
         const auto top_left = sand::config::chunk_size * get_chunk_pos(index);
         for (int y = sand::config::chunk_size; y != 0; --y) {
             if (coin_flip()) {

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -366,16 +366,13 @@ auto update_pixel(world& pixels, glm::ivec2 pos) -> void
 
 auto update(world& w) -> void
 {
-    for (auto& chunk : w.chunks) {
-        chunk.should_step = std::exchange(chunk.should_step_next, false);
-    }
-
     for (auto& pixel : w.pixels) {
         pixel.flags[is_updated] = false;
     }
-
+    
     for (auto it = w.chunks.rbegin(); it != w.chunks.rend(); ++it) {
         auto& chunk = *it;
+        chunk.should_step = std::exchange(chunk.should_step_next, false);
         if (!chunk.should_step) continue;
     
         const auto index = w.chunks.size() - std::distance(w.chunks.rbegin(), it) - 1;
@@ -394,17 +391,7 @@ auto update(world& w) -> void
                 }
             }
         }
-    }
-    
-    
-    for (int x = 0; x != num_chunks; ++x) {
-        for (int y = 0; y != num_chunks; ++y) {
-            const auto pos = glm::ivec2{x, y};
-            auto& chunk = w.chunks[get_chunk_index(pos)];
-            if (chunk.should_step) {
-                create_chunk_triangles(w, pos);
-            }
-        }
+        create_chunk_triangles(w, chunk, top_left);
     }
     
     w.physics.Step(sand::config::time_step, 8, 3);

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -374,21 +374,26 @@ auto update(world& w) -> void
         pixel.flags[is_updated] = false;
     }
 
-    
-    for (int y = sand::config::num_pixels; y != 0; --y) {
-        if (coin_flip()) {
-            for (int x = 0; x != sand::config::num_pixels; ++x) {
-                const auto pos = glm::ivec2{x, y - 1};
-                if (w.is_chunk_awake(pos)) update_pixel(w, pos);
+    for (std::size_t index = 0; index != w.chunks.size(); ++index) {
+        if (!w.chunks[index].should_step) continue;
+
+        const auto top_left = sand::config::chunk_size * get_chunk_pos(index);
+        for (int y = sand::config::chunk_size; y != 0; --y) {
+            if (coin_flip()) {
+                for (int x = 0; x != sand::config::chunk_size; ++x) {
+                    const auto pos = top_left + glm::ivec2{x, y - 1};
+                    update_pixel(w, pos);
+                }
             }
-        }
-        else {
-            for (int x = sand::config::num_pixels; x != 0; --x) {
-                const auto pos = glm::ivec2{x - 1, y - 1};
-                if (w.is_chunk_awake(pos)) update_pixel(w, pos);
+            else {
+                for (int x = sand::config::chunk_size; x != 0; --x) {
+                    const auto pos = top_left + glm::ivec2{x - 1, y - 1};
+                    update_pixel(w, pos);
+                }
             }
         }
     }
+    
     
     for (int x = 0; x != num_chunks; ++x) {
         for (int y = 0; y != num_chunks; ++y) {

--- a/src/update_rigid_bodies.cpp
+++ b/src/update_rigid_bodies.cpp
@@ -363,17 +363,14 @@ auto get_starting_pixel(const chunk_static_pixels& pixels) -> glm::ivec2
     std::unreachable();
 }
 
-auto create_chunk_triangles(sand::world& w, glm::ivec2 chunk_pos) -> void
+auto create_chunk_triangles(world& w, chunk& c, glm::ivec2 top_left) -> void
 {
-    auto& chunk = w.chunks[sand::get_chunk_index(chunk_pos)];
-    
-    if (chunk.triangles) {
-        w.physics.DestroyBody(chunk.triangles);
+    if (c.triangles) {
+        w.physics.DestroyBody(c.triangles);
     }
     
-    chunk.triangles = new_body(w.physics);
+    c.triangles = new_body(w.physics);
     
-    const auto top_left = sand::config::chunk_size * chunk_pos;
     auto chunk_pixels = chunk_static_pixels{};
     
     // Fill up the bitset
@@ -392,7 +389,7 @@ auto create_chunk_triangles(sand::world& w, glm::ivec2 chunk_pos) -> void
         const auto pos = get_starting_pixel(chunk_pixels) + top_left;
         const auto boundary = calc_boundary(top_left, w, pos, 1.5f);
         const auto triangles = triangulate(boundary);
-        add_triangles_to_body(*chunk.triangles, triangles);
+        add_triangles_to_body(*c.triangles, triangles);
         flood_remove(chunk_pixels, pos - top_left);
     }
 }

--- a/src/update_rigid_bodies.hpp
+++ b/src/update_rigid_bodies.hpp
@@ -4,6 +4,7 @@
 namespace sand {
 
 class world;
-auto create_chunk_triangles(world& w, glm::ivec2 chunk_pos) -> void;
+class chunk;
+auto create_chunk_triangles(world& w, chunk& c, glm::ivec2 top_left) -> void;
 
 }


### PR DESCRIPTION
* Rather than looping over pixels, loop over chunks instead.
* This is faster since we don't check if each chunk is awake for every pixel in that chunk; instead we just skip the entire chunk.
* We only need to loop over the chunks once rather than twice + a loop over pixels.