### PR TITLE
Window Cleaning

### DIFF
--- a/src/camera.hpp
+++ b/src/camera.hpp
@@ -6,8 +6,8 @@ namespace sand {
 struct camera
 {
     glm::vec2 top_left;
-    float screen_width;
-    float screen_height;
+    int screen_width;
+    int screen_height;
     float world_to_screen; // the number of screen pixels per world pixel, multiplying by it takes you from world space to screen space
 };
 

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -49,9 +49,12 @@ struct editor
         // 1 == square
         // 2 == explosion
         
-    bool show_chunks = false;
-    bool show_demo = true;
-    int zoom = 256;
+    bool show_chunks  = false;
+    bool show_demo    = true;
+    bool show_physics = false;
+    bool show_spawn   = false;
+
+    int  zoom         = 256;
     
     auto get_pixel() -> sand::pixel
     {

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -55,7 +55,10 @@ struct editor
     bool show_spawn   = false;
 
     int  zoom         = 256;
-    
+
+    int new_world_chunks_width  = 4;
+    int new_world_chunks_height = 4;
+
     auto get_pixel() -> sand::pixel
     {
         return pixel_makers[current].second();

--- a/src/event.hpp
+++ b/src/event.hpp
@@ -100,7 +100,7 @@ public:
 	auto as() const -> const T& { return std::get<T>(d_event); }
 
 	template <typename T>
-	auto get_if() const -> const T* { return std::get_if<T>(d_event); }
+	auto get_if() const -> const T* { return std::get_if<T>(&d_event); }
 
 	template <typename Visitor>
 	auto visit(Visitor&& visitor) const { return std::visit(std::forward<Visitor>(visitor), d_event); }

--- a/src/event.hpp
+++ b/src/event.hpp
@@ -99,6 +99,9 @@ public:
 	template <typename T>
 	auto as() const -> const T& { return std::get<T>(d_event); }
 
+	template <typename T>
+	auto get_if() const -> const T* { return std::get_if<T>(d_event); }
+
 	template <typename Visitor>
 	auto visit(Visitor&& visitor) const { return std::visit(std::forward<Visitor>(visitor), d_event); }
 

--- a/src/event.hpp
+++ b/src/event.hpp
@@ -34,14 +34,12 @@ struct keyboard_typed_event {
 // MOUSE EVENTS
 struct mouse_pressed_event {
 	int button;
-	int action;
 	int mods;
 	glm::vec2 pos;
 };
 
 struct mouse_released_event {
 	int button;
-	int action;
 	int mods;
 	glm::vec2 pos;
 };
@@ -88,10 +86,8 @@ class event
     event_variant d_event;
 
 public:
-	template <typename T, typename... Args>
-	explicit event(std::in_place_type_t<T>, Args&&... args)
-		: d_event(std::in_place_type<T>, std::forward<Args>(args)...)
-	{}
+	template <typename T>
+	explicit event(T&& t) : d_event{t} {}
 
 	template <typename T>
 	auto is() const noexcept -> bool { return std::holds_alternative<T>(d_event); }
@@ -102,19 +98,10 @@ public:
 	template <typename T>
 	auto get_if() const -> const T* { return std::get_if<T>(&d_event); }
 
-	template <typename Visitor>
-	auto visit(Visitor&& visitor) const { return std::visit(std::forward<Visitor>(visitor), d_event); }
-
 	auto is_keyboard_event() const -> bool;
 	auto is_mount_event() const -> bool;
 	auto is_window_event() const -> bool;
 };
-
-template <typename T, typename... Args>
-event make_event(Args&&... args)
-{
-	return event(std::in_place_type<T>, std::forward<Args>(args)...);
-}
 
 inline auto event::is_keyboard_event() const -> bool
 {

--- a/src/event.hpp
+++ b/src/event.hpp
@@ -1,7 +1,6 @@
 #pragma once
 #include <glm/glm.hpp>
 
-#include <any>
 #include <variant>
 #include <string>
 #include <cstdint>
@@ -35,13 +34,11 @@ struct keyboard_typed_event {
 struct mouse_pressed_event {
 	int button;
 	int mods;
-	glm::vec2 pos;
 };
 
 struct mouse_released_event {
 	int button;
 	int mods;
-	glm::vec2 pos;
 };
 
 struct mouse_moved_event {

--- a/src/graphics/renderer.cpp
+++ b/src/graphics/renderer.cpp
@@ -121,7 +121,9 @@ auto renderer::update(const level& world, bool show_chunks, const camera& camera
     d_shader.load_vec2("u_tex_offset", camera.top_left);
     d_shader.load_float("u_world_to_screen", camera.world_to_screen);
 
-    const auto projection = glm::ortho(0.0f, camera.screen_width, camera.screen_height, 0.0f);
+    const auto projection = glm::ortho(
+        0.0f, static_cast<float>(camera.screen_width), static_cast<float>(camera.screen_height), 0.0f
+    );
     d_shader.load_mat4("u_proj_matrix", projection);
 
     const auto& chunks = world.pixels.chunks();

--- a/src/graphics/shape_renderer.cpp
+++ b/src/graphics/shape_renderer.cpp
@@ -48,8 +48,8 @@ in vec4  o_line_begin_colour;
 in vec4  o_line_end_colour;
 in float o_line_thickness;
 
-uniform float u_camera_width;
-uniform float u_camera_height;
+uniform int u_camera_width;
+uniform int u_camera_height;
 uniform vec2 u_camera_top_left;
 uniform float u_camera_world_to_screen;
 
@@ -137,8 +137,8 @@ in vec4  o_circle_begin_colour;
 in vec4  o_circle_end_colour;
 in float o_circle_angle;
 
-uniform float u_camera_width;
-uniform float u_camera_height;
+uniform int u_camera_width;
+uniform int u_camera_height;
 uniform vec2 u_camera_top_left;
 uniform float u_camera_world_to_screen;
 
@@ -321,14 +321,14 @@ void shape_renderer::begin_frame(const camera& c)
     d_quads.clear();
 
     d_line_shader.bind();
-    d_line_shader.load_float("u_camera_width", c.screen_width);
-    d_line_shader.load_float("u_camera_height", c.screen_height);
+    d_line_shader.load_int("u_camera_width", c.screen_width);
+    d_line_shader.load_int("u_camera_height", c.screen_height);
     d_line_shader.load_vec2("u_camera_top_left", c.top_left);
     d_line_shader.load_float("u_camera_world_to_screen", c.world_to_screen);
 
     d_circle_shader.bind();
-    d_circle_shader.load_float("u_camera_width", c.screen_width);
-    d_circle_shader.load_float("u_camera_height", c.screen_height);
+    d_circle_shader.load_int("u_camera_width", c.screen_width);
+    d_circle_shader.load_int("u_camera_height", c.screen_height);
     d_circle_shader.load_vec2("u_camera_top_left", c.top_left);
     d_circle_shader.load_float("u_camera_world_to_screen", c.world_to_screen);
 

--- a/src/graphics/window.cpp
+++ b/src/graphics/window.cpp
@@ -61,19 +61,17 @@ window::window(const std::string& name, int width, int height)
 		glViewport(0, 0, width, height);
 		auto& data = get_window_data(window);
 		if (!data.focused) return;
-		auto event = make_event<window_resize_event>(width, height);
 		data.width = width;
 		data.height = height;
-		data.events.push_back(event);
+		data.events.emplace_back(window_resize_event{width, height});
 	});
 
 	glfwSetWindowCloseCallback(native_window, [](GLFWwindow* window)
 	{
 		auto& data = get_window_data(window);
 		if (!data.focused) return;
-		auto event = make_event<window_closed_event>();
 		data.running = false;
-		data.events.push_back(event);
+		data.events.emplace_back(window_closed_event{});
 	});
 
 	glfwSetKeyCallback(native_window, [](GLFWwindow* window, int key, int scancode, int action, int mods) {
@@ -82,16 +80,13 @@ window::window(const std::string& name, int width, int height)
 		switch (action)
 		{
 			case GLFW_PRESS: {
-				auto event = make_event<keyboard_pressed_event>(key, scancode, mods);
-				data.events.push_back(event);
+				data.events.emplace_back(keyboard_pressed_event{key, scancode, mods});
 			} break;
 			case GLFW_RELEASE: {
-				auto event = make_event<keyboard_released_event>(key, scancode, mods);
-				data.events.push_back(event);
+				data.events.emplace_back(keyboard_released_event{key, scancode, mods});
 			} break;
 			case GLFW_REPEAT: {
-				auto event = make_event<keyboard_held_event>(key, scancode, mods);
-				data.events.push_back(event);
+				data.events.emplace_back(keyboard_held_event{key, scancode, mods});
 			} break;
 		}
 	});
@@ -106,16 +101,10 @@ window::window(const std::string& name, int width, int height)
 		switch (action)
 		{
 		case GLFW_PRESS: {
-			auto event = make_event<mouse_pressed_event>(
-				button, action, mods, glm::vec2{x, y}
-			);
-			data.events.push_back(event);
+			data.events.emplace_back(mouse_pressed_event{button, mods, {x, y}});
 		} break;
 		case GLFW_RELEASE: {
-			auto event = make_event<mouse_released_event>(
-				button, action, mods, glm::vec2{x, y}
-			);
-			data.events.push_back(event);
+			data.events.emplace_back(mouse_released_event{button, mods, {x, y}});
 		} break;
 		}
 	});
@@ -123,49 +112,39 @@ window::window(const std::string& name, int width, int height)
 	glfwSetCursorPosCallback(native_window, [](GLFWwindow* window, double x_pos, double y_pos) {
 		auto& data = get_window_data(window);
 		if (!data.focused) return;
-		auto event = make_event<mouse_moved_event>( glm::vec2{x_pos, y_pos} );
 		data.mouse_pos = {x_pos, y_pos};
-		data.events.push_back(event);
+		data.events.emplace_back(mouse_moved_event{data.mouse_pos});
 	});
 
 	glfwSetScrollCallback(native_window, [](GLFWwindow* window, double x_offset, double y_offset) {
 		auto& data = get_window_data(window);
 		if (!data.focused) return;
-		auto event = make_event<mouse_scrolled_event>(glm::vec2{x_offset, y_offset});
-		data.events.push_back(event);
+		data.events.emplace_back(mouse_scrolled_event{{x_offset, y_offset}});
 	});
 
 	glfwSetWindowFocusCallback(native_window, [](GLFWwindow* window, int focused) {
 		auto& data = get_window_data(window);
+		data.focused = focused;
 		if (focused) {
-			auto event = make_event<window_got_focus_event>();
-			data.focused = true;
-			data.events.push_back(event);
-		}
-		else {
-			auto event = make_event<window_lost_focus_event>();
-			data.focused = false;
-			data.events.push_back(event);
+			data.events.emplace_back(window_got_focus_event{});
+		} else {
+			data.events.emplace_back(window_lost_focus_event{});
 		}
 	});
 
 	glfwSetWindowMaximizeCallback(native_window, [](GLFWwindow* window, int maximized) {
 		auto& data = get_window_data(window);
 		if (maximized) {
-			auto event = make_event<window_maximise_event>();
-			data.events.push_back(event);
-		}
-		else {
-			auto event = make_event<window_minimise_event>();
-			data.events.push_back(event);
+			data.events.emplace_back(window_maximise_event{});
+		} else {
+			data.events.emplace_back(window_minimise_event{});
 		}
 	});
 
 	glfwSetCharCallback(native_window, [](GLFWwindow* window, std::uint32_t key) {
 		auto& data = get_window_data(window);
 		if (!data.focused) return;
-		auto event = make_event<keyboard_typed_event>(key);
-		data.events.push_back(event);
+		data.events.emplace_back(keyboard_typed_event{key});
 	});
 }
 

--- a/src/graphics/window.cpp
+++ b/src/graphics/window.cpp
@@ -94,15 +94,14 @@ window::window(const std::string& name, int width, int height)
 	glfwSetMouseButtonCallback(native_window, [](GLFWwindow* window, int button, int action, int mods) {
 		auto& data = get_window_data(window);
 		if (!data.focused) return;
-
 		switch (action)
 		{
-		case GLFW_PRESS: {
-			data.events.emplace_back(mouse_pressed_event{button, mods});
-		} break;
-		case GLFW_RELEASE: {
-			data.events.emplace_back(mouse_released_event{button, mods});
-		} break;
+			case GLFW_PRESS: {
+				data.events.emplace_back(mouse_pressed_event{button, mods});
+			} break;
+			case GLFW_RELEASE: {
+				data.events.emplace_back(mouse_released_event{button, mods});
+			} break;
 		}
 	});
 
@@ -177,11 +176,6 @@ bool window::is_running() const
 glm::vec2 window::get_mouse_pos() const
 {
     return d_data.mouse_pos;
-}
-
-void window::set_name(const std::string& name)
-{
-    glfwSetWindowTitle(d_data.native_window, name.c_str());
 }
 
 auto window::width() const -> int

--- a/src/graphics/window.cpp
+++ b/src/graphics/window.cpp
@@ -95,16 +95,13 @@ window::window(const std::string& name, int width, int height)
 		auto& data = get_window_data(window);
 		if (!data.focused) return;
 
-		double x, y;
-    	glfwGetCursorPos(data.native_window, &x, &y);
-
 		switch (action)
 		{
 		case GLFW_PRESS: {
-			data.events.emplace_back(mouse_pressed_event{button, mods, {x, y}});
+			data.events.emplace_back(mouse_pressed_event{button, mods});
 		} break;
 		case GLFW_RELEASE: {
-			data.events.emplace_back(mouse_released_event{button, mods, {x, y}});
+			data.events.emplace_back(mouse_released_event{button, mods});
 		} break;
 		}
 	});

--- a/src/graphics/window.cpp
+++ b/src/graphics/window.cpp
@@ -18,23 +18,19 @@ auto get_window_data(GLFWwindow* window) -> window_data&
 
 }
 
-window::window(const std::string& name, int width, int height)
-    : d_data({name, width, height, true, true, true})
+window::window(const char* name, int width, int height)
+    : d_data({width, height, true, true, true})
 {
     if (GLFW_TRUE != glfwInit()) {
 		std::print("FATAL: Failed to initialise GLFW\n");
 		std::exit(-1);
 	}
 
-	auto native_window = glfwCreateWindow(width, height, name.c_str(), nullptr, nullptr);
+	auto native_window = glfwCreateWindow(width, height, name, nullptr, nullptr);
 	if (!native_window) {
 		std::print("FATAL: Failed to create window\n");
 		std::exit(-2);
 	}
-
-	double x = 0, y = 0;
-	glfwGetCursorPos(native_window, &x, &y);
-	d_data.mouse_pos = {x, y};
 
 	d_data.native_window = native_window;
 
@@ -108,8 +104,7 @@ window::window(const std::string& name, int width, int height)
 	glfwSetCursorPosCallback(native_window, [](GLFWwindow* window, double x_pos, double y_pos) {
 		auto& data = get_window_data(window);
 		if (!data.focused) return;
-		data.mouse_pos = {x_pos, y_pos};
-		data.events.emplace_back(mouse_moved_event{data.mouse_pos});
+		data.events.emplace_back(mouse_moved_event{{x_pos, y_pos}});
 	});
 
 	glfwSetScrollCallback(native_window, [](GLFWwindow* window, double x_offset, double y_offset) {
@@ -171,11 +166,6 @@ auto window::events() -> std::span<const event>
 bool window::is_running() const
 {
     return d_data.running;
-}
-
-glm::vec2 window::get_mouse_pos() const
-{
-    return d_data.mouse_pos;
 }
 
 auto window::width() const -> int

--- a/src/graphics/window.hpp
+++ b/src/graphics/window.hpp
@@ -17,8 +17,6 @@ using window_callback = std::function<void(const event&)>;
 
 struct window_data
 {
-    std::string name;
-
     int width;
     int height;
 
@@ -26,15 +24,14 @@ struct window_data
     bool running;
     bool focused;
 
-    glm::vec2       mouse_pos     = {0.0, 0.0};
-    GLFWwindow*     native_window = nullptr;
+    GLFWwindow* native_window = nullptr;
 
     std::vector<event> events;
 };
 
 class window
 {
-    window_data d_data;
+   window_data d_data;
 
     window(const window&) = delete;
     window& operator=(const window&) = delete;
@@ -43,7 +40,7 @@ class window
     window& operator=(window&&) = delete;
 
 public:
-    window(const std::string& name, int width, int height);
+    window(const char* name, int width, int height);
     ~window();
 
     auto begin_frame() -> void;
@@ -51,8 +48,6 @@ public:
     auto events() -> std::span<const event>;
 
     auto is_running() const -> bool;
-
-    auto get_mouse_pos() const -> glm::vec2;
 
     auto width() const -> int;
     auto height() const -> int;

--- a/src/graphics/window.hpp
+++ b/src/graphics/window.hpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <string>
 #include <cstdint>
+#include <span>
 #include <functional>
 
 struct GLFWwindow;
@@ -27,7 +28,8 @@ struct window_data
 
     glm::vec2       mouse_pos     = {0.0, 0.0};
     GLFWwindow*     native_window = nullptr;
-    window_callback callback      = {};
+
+    std::vector<event> events;
 };
 
 class window
@@ -44,16 +46,15 @@ public:
     window(const std::string& name, int width, int height);
     ~window();
 
-    auto clear() const -> void;
-    auto swap_buffers() -> void;
-    auto poll_events() -> void;
+    auto begin_frame() -> void;
+    auto end_frame() -> void;
+    auto events() -> std::span<const event>;
 
     auto is_running() const -> bool;
 
     auto get_mouse_pos() const -> glm::vec2;
 
     auto set_name(const std::string& name) -> void;
-    auto set_callback(const window_callback& callback) -> void;
 
     auto width() const -> int;
     auto height() const -> int;

--- a/src/graphics/window.hpp
+++ b/src/graphics/window.hpp
@@ -54,8 +54,6 @@ public:
 
     auto get_mouse_pos() const -> glm::vec2;
 
-    auto set_name(const std::string& name) -> void;
-
     auto width() const -> int;
     auto height() const -> int;
 

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -6,17 +6,17 @@
 
 namespace sand {
 
-auto mouse::on_event(const event& e) -> void
+auto mouse::on_event(const event& event) -> void
 {
-    if (e.is<sand::mouse_pressed_event>()) {
-        d_down[e.as<sand::mouse_pressed_event>().button] = true;
-        d_down_this_frame[e.as<sand::mouse_pressed_event>().button] = true;
+    if (const auto e = event.get_if<sand::mouse_pressed_event>()) {
+        d_down[e->button] = true;
+        d_down_this_frame[e->button] = true;
     }
-    else if (e.is<sand::mouse_released_event>()) {
-        d_down[e.as<sand::mouse_released_event>().button] = false;
+    else if (const auto e = event.get_if<sand::mouse_released_event>()) {
+        d_down[e->button] = false;
     }
-    else if (e.is<sand::mouse_moved_event>()) {
-        d_positiion_this_frame = e.as<sand::mouse_moved_event>().pos;
+    else if (const auto e = event.get_if<sand::mouse_moved_event>()) {
+        d_positiion_this_frame = e->pos;
     }
 }
 
@@ -42,14 +42,14 @@ auto mouse::offset() const -> glm::vec2
 }
 
 
-auto keyboard::on_event(const event& e) -> void
+auto keyboard::on_event(const event& event) -> void
 {
-    if (e.is<sand::keyboard_pressed_event>()) {
-        d_down[e.as<sand::keyboard_pressed_event>().key] = true;
-        d_down_this_frame[e.as<sand::keyboard_pressed_event>().key] = true;
+    if (const auto e = event.get_if<sand::keyboard_pressed_event>()) {
+        d_down[e->key] = true;
+        d_down_this_frame[e->key] = true;
     }
-    else if (e.is<sand::keyboard_released_event>()) {
-        d_down[e.as<sand::keyboard_released_event>().key] = false;
+    else if (const auto e = event.get_if<sand::keyboard_released_event>()) {
+        d_down[e->key] = false;
     }
 }
 

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -41,6 +41,11 @@ auto mouse::offset() const -> glm::vec2
     return d_positiion_this_frame - d_position_last_frame;
 }
 
+auto mouse::position() const -> glm::vec2
+{
+    return d_positiion_this_frame;
+}
+
 
 auto keyboard::on_event(const event& event) -> void
 {

--- a/src/mouse.hpp
+++ b/src/mouse.hpp
@@ -25,6 +25,7 @@ public:
     auto is_down(mouse_button button) const -> bool;
     auto is_down_this_frame(mouse_button button) const-> bool;
     auto offset() const -> glm::vec2;
+    auto position() const -> glm::vec2;
 };
 
 enum class keyboard_key

--- a/src/player.hpp
+++ b/src/player.hpp
@@ -144,9 +144,6 @@ public:
 
         const auto vel = d_body->GetLinearVelocity();
         
-        const auto go_l = can_move_left && k.is_down(sand::keyboard_key::A);
-        const auto go_r = can_move_right && k.is_down(sand::keyboard_key::D);
-        
         auto direction = 0;
         if (can_move_left && k.is_down(sand::keyboard_key::A)) {
             direction -= 1;

--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -159,8 +159,8 @@ auto main() -> int
 
     auto camera = sand::camera{
         .top_left = {0, 0},
-        .screen_width = static_cast<float>(window.width()),
-        .screen_height = static_cast<float>(window.height()),
+        .screen_width = window.width(),
+        .screen_height = window.height(),
         .world_to_screen = 720.0f / 256.0f
     };
 
@@ -171,8 +171,6 @@ auto main() -> int
     auto shape_renderer  = sand::shape_renderer{};
     auto debug_draw      = physics_debug_draw{&shape_renderer};
     debug_draw.SetFlags(b2Draw::e_shapeBit);
-    auto show_physics = false;
-    auto show_spawn     = false;
 
     auto new_world_chunks_width  = 4;
     auto new_world_chunks_height = 4;
@@ -213,7 +211,6 @@ auto main() -> int
                 camera.top_left -= new_centre - old_centre;
             }
         }
-
 
         if (mouse.is_down(sand::mouse_button::right)) {
             camera.top_left -= mouse.offset() / camera.world_to_screen;
@@ -287,8 +284,8 @@ auto main() -> int
             ImGui::Text("Scale: %f", camera.world_to_screen);
 
             ImGui::Separator();
-            ImGui::Checkbox("Show Physics", &show_physics);
-            ImGui::Checkbox("Show Spawn", &show_spawn);
+            ImGui::Checkbox("Show Physics", &editor.show_physics);
+            ImGui::Checkbox("Show Spawn", &editor.show_spawn);
             ImGui::SliderInt("Spawn X", &level->spawn_point.x, 0, level->pixels.width());
             ImGui::SliderInt("Spawn Y", &level->spawn_point.y, 0, level->pixels.height());
             if (ImGui::Button("Respawn")) {
@@ -370,12 +367,12 @@ auto main() -> int
         // TODO: Replace with actual sprite data
         shape_renderer.draw_circle(level->player.centre(), {1.0, 1.0, 0.0, 1.0}, 3);
 
-        if (show_physics) {
+        if (editor.show_physics) {
             level->pixels.physics().SetDebugDraw(&debug_draw);
             level->pixels.physics().DebugDraw();
         }
 
-        if (show_spawn) {
+        if (editor.show_spawn) {
             shape_renderer.draw_circle(level->spawn_point, {0, 1, 0, 1}, 1.0);
         }
 

--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -326,9 +326,6 @@ auto main() -> int
                     std::istreambuf_iterator<char>()
                 );
                 std::print("loaded a file containing {} bytes\n", buffer.size());
-                if (buffer.size() >= 8) {
-                    std::print("{} {} {} {} {} {} {} {}\n", (std::uint8_t)buffer[0], (int)buffer[1],(int)buffer[2],(int)buffer[3],(int)buffer[4],(int)buffer[5],(int)buffer[6],(int)buffer[7]);
-                }
             }
         }
         ImGui::End();

--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -181,10 +181,10 @@ auto main() -> int
                 camera.screen_height = e->height;
             }
             else if (const auto e = event.get_if<sand::mouse_scrolled_event>()) {
-                const auto old_centre = mouse_pos_world_space(window, camera);
+                const auto old_centre = mouse_pos_world_space(mouse, camera);
                 camera.world_to_screen += 0.1f * e->offset.y;
                 camera.world_to_screen = std::clamp(camera.world_to_screen, 1.0f, 100.0f);
-                const auto new_centre = mouse_pos_world_space(window, camera);
+                const auto new_centre = mouse_pos_world_space(mouse, camera);
                 camera.top_left -= new_centre - old_centre;
             }
         }
@@ -202,7 +202,7 @@ auto main() -> int
         }
         level->player.update(keyboard);
 
-        const auto mouse_pos = pixel_at_mouse(window, camera);
+        const auto mouse_pos = pixel_at_mouse(mouse, camera);
         switch (editor.brush_type) {
             break; case 0:
                 if (mouse.is_down(sand::mouse_button::left)) {
@@ -237,8 +237,8 @@ auto main() -> int
         ImGui_ImplGlfw_NewFrame();
         ImGui::NewFrame();
 
-        const auto mouse_actual = mouse_pos_world_space(window, camera);
-        const auto mouse = pixel_at_mouse(window, camera);
+        const auto mouse_actual = mouse_pos_world_space(mouse, camera);
+        const auto mouse_pixel = pixel_at_mouse(mouse, camera);
 
         ImGui::ShowDemoWindow(&editor.show_demo);
 
@@ -246,9 +246,9 @@ auto main() -> int
             ImGui::Text("Mouse");
             ImGui::Text("Position: {%.2f, %.2f}", mouse_actual.x, mouse_actual.y);
             ImGui::Text("Position: {%d, %d}", (int)std::round(mouse_actual.x), (int)std::round(mouse_actual.y));
-            ImGui::Text("Pixel: {%d, %d}", mouse.x, mouse.y);
-            if (level->pixels.valid(mouse)) {
-                const auto px = level->pixels[mouse];
+            ImGui::Text("Pixel: {%d, %d}", mouse_pixel.x, mouse_pixel.y);
+            if (level->pixels.valid(mouse_pixel)) {
+                const auto px = level->pixels[mouse_pixel];
                 ImGui::Text("  pixel power: %d", px.power);
             }
             ImGui::Text("Number of Floors: %d", level->player.floors().size());

--- a/src/sandfall.m.cpp
+++ b/src/sandfall.m.cpp
@@ -199,8 +199,8 @@ auto main() -> int
             accumulator -= sand::config::time_step;
             updated = true;
             level->pixels.step();
-            level->player.update(keyboard);
         }
+        level->player.update(keyboard);
 
         const auto mouse_pos = pixel_at_mouse(window, camera);
         switch (editor.brush_type) {
@@ -252,6 +252,7 @@ auto main() -> int
                 ImGui::Text("  pixel power: %d", px.power);
             }
             ImGui::Text("Number of Floors: %d", level->player.floors().size());
+            ImGui::Text("Events this frame: %zu", window.events().size());
             ImGui::Separator();
 
             ImGui::Text("Camera");

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -1,5 +1,6 @@
 #include "utility.hpp"
 #include "camera.hpp"
+#include "mouse.hpp"
 #include "graphics/window.hpp"
 
 #include <array>
@@ -112,14 +113,14 @@ auto get_executable_filepath() -> std::filesystem::path
     }
 }
 
-auto mouse_pos_world_space(const sand::window& w, const sand::camera& c) -> glm::vec2
+auto mouse_pos_world_space(const mouse& m, const sand::camera& c) -> glm::vec2
 {
-    return w.get_mouse_pos() / c.world_to_screen + c.top_left;
+    return m.position() / c.world_to_screen + c.top_left;
 }
 
-auto pixel_at_mouse(const sand::window& w, const sand::camera& c) -> glm::ivec2
+auto pixel_at_mouse(const mouse& m, const sand::camera& c) -> glm::ivec2
 {
-    return glm::ivec2{mouse_pos_world_space(w, c)};
+    return glm::ivec2{mouse_pos_world_space(m, c)};
 }
 
 auto pixel_to_physics(glm::vec2 px) -> b2Vec2

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -11,7 +11,6 @@
 #include <box2d/box2d.h>
 
 #include "config.hpp"
-#include "mouse.hpp"
 
 namespace sand {
 
@@ -92,6 +91,7 @@ auto lerp(const T& a, const T& b, float t) -> T
 };
 
 struct camera;
+class mouse;
 auto mouse_pos_world_space(const mouse& m, const camera& c) -> glm::vec2;
 auto pixel_at_mouse(const mouse& m, const camera& c) -> glm::ivec2;
 

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -91,7 +91,6 @@ auto lerp(const T& a, const T& b, float t) -> T
     return t * b + (1 - t) * a;
 };
 
-class window;
 struct camera;
 auto mouse_pos_world_space(const mouse& m, const camera& c) -> glm::vec2;
 auto pixel_at_mouse(const mouse& m, const camera& c) -> glm::ivec2;

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -11,6 +11,7 @@
 #include <box2d/box2d.h>
 
 #include "config.hpp"
+#include "mouse.hpp"
 
 namespace sand {
 
@@ -92,8 +93,8 @@ auto lerp(const T& a, const T& b, float t) -> T
 
 class window;
 struct camera;
-auto mouse_pos_world_space(const window& w, const camera& c) -> glm::vec2;
-auto pixel_at_mouse(const window& w, const camera& c) -> glm::ivec2;
+auto mouse_pos_world_space(const mouse& m, const camera& c) -> glm::vec2;
+auto pixel_at_mouse(const mouse& m, const camera& c) -> glm::ivec2;
 
 auto pixel_to_physics(glm::vec2 px) -> b2Vec2;
 auto pixel_to_physics(float px) -> float;


### PR DESCRIPTION
* Cleaned up a lot of the window code to make it simpler.
* Events are now stored in a vector which should be processed in the game loop, rather than via a callback. This just makes it far easier to see the order of operations in a single frame.
* Simplified the construction of events too, no more complex forwarding code; just pass the variant sub-elements directly. All event types just hold ints anyway so trivial to copy around.
* Rather than exposing separate `poll_events`, `swap_buffers` and `clear` functions, the window just has `begin_frame` and `end_frame` now, plus an `events` functions to return a span of the events for the given frame.
* Removed a bunch of unused functions from the window.
* Removed the mouse pos stored in the variable, you should get this from the `mouse` object instead.
* Move a bunch of editor specific values to the editor struct.
* Added some code to load files, currently doesn't do anything except print the size, but in the future I want to make it possible to load PNG files to construct worlds from. I'll expand on this with a proper editor.