### PR TITLE
Fix `is_falling` Flag Staying True

### DIFF
--- a/imgui.ini
+++ b/imgui.ini
@@ -8,6 +8,6 @@ Size=476,528
 Collapsed=1
 
 [Window][Editor]
-Pos=780,53
+Pos=855,51
 Size=411,604
 

--- a/src/core/utility.hpp
+++ b/src/core/utility.hpp
@@ -28,22 +28,6 @@ struct overloaded : Ts...
     using Ts::operator()...;
 };
 
-template <typename Func>
-class scope_exit
-{
-    Func d_func;
-
-    scope_exit(const scope_exit&) = delete;
-    scope_exit& operator=(const scope_exit&) = delete;
-
-    scope_exit(scope_exit&&) = delete;
-    scope_exit& operator=(scope_exit&&) = delete;
-
-public:
-    scope_exit(Func&& func) : d_func(std::move(func)) {}
-    ~scope_exit() { d_func(); }
-};
-
 class timer
 {
     using clock = std::chrono::steady_clock;

--- a/src/core/world.cpp
+++ b/src/core/world.cpp
@@ -173,7 +173,7 @@ auto should_get_powered(const world& w, glm::ivec2 pos, glm::ivec2 offset) -> bo
 
     // diode_out can *only* be powered by diode_in and itself
     if (dst.type == pixel_type::diode_out && src.type != pixel_type::diode_in
-                                            && src.type != pixel_type::diode_out) {
+                                          && src.type != pixel_type::diode_out) {
         return false;
     }
 


### PR DESCRIPTION
* In the exit scope handler in the position updated, the check was `pos != old_pos` rather than `pos == old_pos`, not quite sure how I managed to introduce that in a previous commit.
* Moved the code to the outer function and removed the `scope_exit` to make things easier to follow.
* Few other bits of clean up.