### PR TITLE
Main Menu

### DIFF
--- a/src/core/ui.cpp
+++ b/src/core/ui.cpp
@@ -109,7 +109,7 @@ static auto is_in_region(glm::vec2 pos, glm::vec2 centre, f32 width, f32 height)
         && (centre.y - height / 2) <= pos.y && pos.y < (centre.y + height / 2);
 }
 
-void ui_engine::draw_frame(const camera& c, f64 dt)
+void ui_engine::draw_frame(i32 screen_width, i32 screen_height, f64 dt)
 {
     // Clean out any elements no longer around
     std::erase_if(d_data, [&](auto& elem) {
@@ -157,7 +157,7 @@ void ui_engine::draw_frame(const camera& c, f64 dt)
     glBlendEquation(GL_FUNC_ADD);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-    const auto dimensions = glm::vec2{c.screen_width, c.screen_height};
+    const auto dimensions = glm::vec2{screen_width, screen_height};
     const auto projection = glm::ortho(0.0f, dimensions.x, dimensions.y, 0.0f);
     
     d_shader.bind();

--- a/src/core/ui.cpp
+++ b/src/core/ui.cpp
@@ -189,7 +189,7 @@ bool ui_engine::on_event(const event& event)
 
 bool ui_engine::button(std::string_view name, glm::vec2 pos, f32 width, f32 height)
 {
-    auto& data = get_data(name, pos, width, height);
+    const auto& data = get_data(name, pos, width, height);
     
     const auto hovered_colour = glm::vec4{1, 0, 1, 1};
     const auto unhovered_colour = glm::vec4{1, 0, 0, 1};

--- a/src/core/ui.cpp
+++ b/src/core/ui.cpp
@@ -191,22 +191,25 @@ bool ui_engine::button(std::string_view name, glm::vec2 pos, f32 width, f32 heig
 {
     const auto& data = get_data(name, pos, width, height);
     
-    const auto hovered_colour = glm::vec4{1, 0, 1, 1};
-    const auto unhovered_colour = glm::vec4{1, 0, 0, 1};
+    constexpr auto unhovered_colour = from_hex(0x17c0eb);
+    constexpr auto hovered_colour = from_hex(0x18dcff);
+    constexpr auto clicked_colour = from_hex(0xfffa65);
+
+    const auto lerp_time = 0.1;
     
-    auto colour = glm::vec4{1, 0, 0, 1};
+    auto colour = unhovered_colour;
     auto extra_width = 0.0f;
     if (data.is_clicked()) {
-        colour = {1, 1, 0, 1};
+        colour = clicked_colour;
         extra_width = 10.0f;
     }
     else if (data.is_hovered()) {
-        const auto t = std::clamp(data.time_hovered(d_time) / 0.2, 0.0, 1.0);
+        const auto t = std::clamp(data.time_hovered(d_time) / lerp_time, 0.0, 1.0);
         colour = sand::lerp(unhovered_colour, hovered_colour, t);
         extra_width = sand::lerp(0.0f, 10.0f, t);
     }
-    else if (d_time > 0.2) { // Don't start the game looking hovered
-        const auto t = std::clamp(data.time_unhovered(d_time) / 0.2, 0.0, 1.0);
+    else if (d_time > lerp_time) { // Don't start the game looking hovered
+        const auto t = std::clamp(data.time_unhovered(d_time) / lerp_time, 0.0, 1.0);
         colour = sand::lerp(hovered_colour, unhovered_colour, t);
         extra_width = sand::lerp(10.0f, 0.0f, t);
     }

--- a/src/core/ui.hpp
+++ b/src/core/ui.hpp
@@ -75,7 +75,7 @@ class ui_engine
 
     std::unordered_map<std::string_view, ui_logic_quad> d_data;
 
-    ui_logic_quad& get_data(std::string_view name, glm::vec2 pos, f32 width, f32 height) { 
+    const ui_logic_quad& get_data(std::string_view name, glm::vec2 pos, f32 width, f32 height) { 
         auto& data = d_data[name];
         data.active = true; // keep this alive
         data.centre = pos + glm::vec2{width/2, height/2};

--- a/src/core/ui.hpp
+++ b/src/core/ui.hpp
@@ -2,7 +2,6 @@
 #include "buffer.hpp"
 #include "shader.hpp"
 #include "texture.hpp"
-#include "camera.hpp"
 #include "event.hpp"
 #include "common.hpp"
 
@@ -99,7 +98,7 @@ public:
     bool button(std::string_view name, glm::vec2 pos, float width, float height);
     
     // Step 3: draw
-    void draw_frame(const camera& c, f64 dt);
+    void draw_frame(i32 screen_width, i32 screen_height, f64 dt);
 };
 
 }

--- a/src/core/utility.cpp
+++ b/src/core/utility.cpp
@@ -86,20 +86,6 @@ auto _print_inner(const std::string& msg) -> void
     std::cout << msg;
 }
 
-auto from_hex(int hex) -> glm::vec4
-{
-    static constexpr auto normalise = [](int x) {
-        return static_cast<float>(x) / 256.0f;
-    };
-
-    const float blue = normalise(hex & 0xff);
-    hex /= 0x100;
-    const float green = normalise(hex & 0xff);
-    hex /= 0x100;
-    const float red = normalise(hex & 0xff);
-    return glm::vec4{red, green, blue, 1.0f};
-}
-
 auto get_executable_filepath() -> std::filesystem::path
 {
     auto buffer = std::vector<char>{};

--- a/src/core/utility.hpp
+++ b/src/core/utility.hpp
@@ -64,7 +64,15 @@ auto coin_flip() -> bool;
 auto sign_flip() -> int;
 auto random_unit() -> float; // Same as random_from_range(0.0f, 1.0f)
 
-auto from_hex(int hex) -> glm::vec4;
+consteval auto from_hex(int hex) -> glm::vec4
+{
+    const float blue = static_cast<float>(hex & 0xff) / 256.0f;
+    hex /= 0x100;
+    const float green = static_cast<float>(hex & 0xff) / 256.0f;
+    hex /= 0x100;
+    const float red = static_cast<float>(hex & 0xff) / 256.0f;
+    return glm::vec4{red, green, blue, 1.0f};
+}
 
 auto get_executable_filepath() -> std::filesystem::path;
 

--- a/src/core/window.cpp
+++ b/src/core/window.cpp
@@ -145,12 +145,12 @@ window::~window()
     glfwTerminate();
 }
 
-auto window::begin_frame() -> void
+auto window::begin_frame(glm::vec4 colour) -> void
 {
     d_data.events.clear();
     glfwPollEvents();
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
-    glClearColor(0.0, 0.0, 0.0, 1.0);
+    glClearColor(colour.r, colour.g, colour.b, colour.a);
 }
 
 auto window::end_frame() -> void

--- a/src/core/window.hpp
+++ b/src/core/window.hpp
@@ -43,7 +43,7 @@ public:
     window(const char* name, int width, int height);
     ~window();
 
-    auto begin_frame() -> void;
+    auto begin_frame(glm::vec4 colour = {0, 0, 0, 1}) -> void;
     auto end_frame() -> void;
     auto events() -> std::span<const event>;
 

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -16,11 +16,42 @@
 #include <memory>
 #include <print>
 
-auto main() -> int
+enum class next_state
+{
+    main_menu,
+    level,
+};
+
+auto scene_main_menu(sand::window& window) -> void
 {
     using namespace sand;
+    auto timer           = sand::timer{};
+    auto ui              = sand::ui_engine{};
 
-    auto window          = sand::window{"sandfall", 1280, 720};
+    while (window.is_running()) {
+        const double dt = timer.on_update();
+        window.begin_frame();
+
+        for (const auto event : window.events()) {
+            if (ui.on_event(event)) { continue; }
+        }
+
+        if (ui.button("button1", {100, 100}, 100, 100)) {
+            std::print("button 1 pressed!\n");
+        }
+
+        if (ui.button("button2", {250, 100}, 100, 100)) {
+            std::print("button 2 pressed!\n");
+        }
+        
+        ui.draw_frame(window.width(), window.height(), dt);
+        window.end_frame();
+    }
+}
+
+auto scene_level(sand::window& window) -> void
+{
+    using namespace sand;
     auto input           = sand::input{};
     auto level           = sand::load_level("save4.bin");
     auto world_renderer  = sand::renderer{static_cast<u32>(level->pixels.width_in_pixels()), static_cast<u32>(level->pixels.height_in_pixels())};
@@ -107,8 +138,20 @@ auto main() -> int
             std::print("button 2 pressed!\n");
         }
         
-        ui.draw_frame(camera, dt);
+        ui.draw_frame(window.width(), window.height(), dt);
         window.end_frame();
+    }
+}
+
+auto main() -> int
+{
+    using namespace sand;
+
+    auto window = sand::window{"sandfall", 1280, 720};
+    auto next   = next_state::main_menu;
+
+    while (window.is_running()) {
+        scene_main_menu(window);
     }
     
     return 0;

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -38,12 +38,13 @@ auto scene_main_menu(sand::window& window) -> next_state
         }
 
         if (ui.button("button1", {100, 100}, 100, 100)) {
-            std::print("button 1 pressed!\n");
+            std::print("loading level!\n");
             return next_state::level;
         }
 
         if (ui.button("button2", {250, 100}, 100, 100)) {
-            std::print("button 2 pressed!\n");
+            std::print("exiting!\n");
+            return next_state::exit;
         }
         
         ui.draw_frame(window.width(), window.height(), dt);

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -29,7 +29,7 @@ auto scene_main_menu(sand::window& window) -> next_state
     auto timer           = sand::timer{};
     auto ui              = sand::ui_engine{};
 
-    const auto clear_colour = from_hex(0x303952);
+    constexpr auto clear_colour = from_hex(0x3d3d3d);
 
     while (window.is_running()) {
         const double dt = timer.on_update();
@@ -44,7 +44,7 @@ auto scene_main_menu(sand::window& window) -> next_state
             return next_state::level;
         }
 
-        if (ui.button("button2", {250, 100}, 100, 100)) {
+        if (ui.button("button2", {100, 250}, 100, 100)) {
             std::print("exiting!\n");
             return next_state::exit;
         }

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -29,9 +29,11 @@ auto scene_main_menu(sand::window& window) -> next_state
     auto timer           = sand::timer{};
     auto ui              = sand::ui_engine{};
 
+    const auto clear_colour = from_hex(0x303952);
+
     while (window.is_running()) {
         const double dt = timer.on_update();
-        window.begin_frame();
+        window.begin_frame(clear_colour);
 
         for (const auto event : window.events()) {
             ui.on_event(event);


### PR DESCRIPTION
* Added a main menu with two buttons; one that loads the level like normal, and an exit button.
* `game.exe` now has a slightly more complex game loop; there is an outer `while (true)` loop that contains a switch, and each branch calls into its own `while (window.is_running())` loop, that way we don't need to check what scene we're in every frame. Each of these return an enum value for the next scene. This will get more complicated as scenes will need to send data between themselves to tell them what to load, ie- the world scene will need to be told what level to load.
* Make `from_hex` a `consteval` function since we only ever call it with hardcoded values that shouldn't be recomputed every frame.
* Made the buttons on the UI look a little nicer.
* `window::begin_frame` now takes a colour value which is used to clear the screen. The default value is still black like before.