### PR TITLE
Buttons with Text

### DIFF
--- a/src/core/ui.cpp
+++ b/src/core/ui.cpp
@@ -17,7 +17,7 @@ auto load_pixel_font_atlas() -> font_atlas
     font_atlas atlas;
     atlas.texture = std::make_unique<texture_png>("res\\pixel_font.png");
     atlas.missing_char = { .position{24, 52}, .size{5, 6}, .bearing{0, -6}, .advance=6 };
-    atlas.height = 5;
+    atlas.height = 7;
     
     atlas.chars['A'] = { .position{0, 0}, .size={5, 7}, .bearing={0, -7}, .advance=6 };
     atlas.chars['B'] = { .position{6, 0}, .size={5, 7}, .bearing={0, -7}, .advance=6 };
@@ -195,6 +195,19 @@ auto font_atlas::get_character(char c) const -> const character&
     return missing_char;
 }
 
+auto font_atlas::length_of(std::string_view message) -> i32
+{
+    if (message.empty()) {
+        return 0;
+    }
+    i32 length = 0;
+    for (char c : message | std::views::drop(1)) {
+        length += get_character(c).advance;
+    }
+    length += get_character(message.back()).size.x;
+    return length;
+}
+
 void ui_graphics_quad::set_buffer_attributes(std::uint32_t vbo)
 {
     glBindBuffer(GL_ARRAY_BUFFER, vbo);
@@ -336,34 +349,31 @@ bool ui_engine::button(
 {
     const auto& data = get_data(key, pos, width, height);
     
-    constexpr auto unhovered_colour = from_hex(0x17c0eb);
-    constexpr auto hovered_colour = from_hex(0x18dcff);
-    constexpr auto clicked_colour = from_hex(0xfffa65);
+    constexpr auto unhovered_colour = from_hex(0x341f97);
+    constexpr auto hovered_colour = from_hex(0x5f27cd);
+    constexpr auto clicked_colour = from_hex(0x48dbfb);
 
     const auto lerp_time = 0.1;
     
     auto colour = unhovered_colour;
-    auto extra_width = 0;
     if (data.is_clicked()) {
         colour = clicked_colour;
-        extra_width = 10;
     }
     else if (data.is_hovered()) {
         const auto t = std::clamp(data.time_hovered(d_time) / lerp_time, 0.0, 1.0);
         colour = sand::lerp(unhovered_colour, hovered_colour, t);
-        extra_width = sand::lerp(0, 10, t);
     }
     else if (d_time > lerp_time) { // Don't start the game looking hovered
         const auto t = std::clamp(data.time_unhovered(d_time) / lerp_time, 0.0, 1.0);
         colour = sand::lerp(hovered_colour, unhovered_colour, t);
-        extra_width = sand::lerp(10, 0, t);
     }
     
-    const auto quad = ui_graphics_quad{pos, width + extra_width, height, 0.0f, colour, 0, {0, 0}, {0, 0}};
+    const auto quad = ui_graphics_quad{pos, width, height, 0.0f, colour, 0, {0, 0}, {0, 0}};
     d_quads.emplace_back(quad);
 
     if (!msg.empty()) {
         auto text_pos = pos;
+        text_pos.x += (width - d_atlas.length_of(msg) * scale) / 2;
         text_pos.y += (height + d_atlas.height * scale) / 2;
         text(msg, text_pos, scale);
     }
@@ -372,7 +382,7 @@ bool ui_engine::button(
 
 void ui_engine::text(std::string_view message, glm::ivec2 pos, i32 size)
 {
-    constexpr auto colour = from_hex(0xd2dae2);
+    constexpr auto colour = from_hex(0xff9ff3);
     for (char c : message) {
         const auto ch = d_atlas.get_character(c);
 

--- a/src/core/ui.cpp
+++ b/src/core/ui.cpp
@@ -330,9 +330,9 @@ bool ui_engine::on_event(const event& event)
     return false;
 }
 
-bool ui_engine::button(std::string_view name, glm::vec2 pos, f32 width, f32 height)
+bool ui_engine::button(glm::vec2 pos, f32 width, f32 height, const widget_key& key)
 {
-    const auto& data = get_data(name, pos, width, height);
+    const auto& data = get_data(key, pos, width, height);
     
     constexpr auto unhovered_colour = from_hex(0x17c0eb);
     constexpr auto hovered_colour = from_hex(0x18dcff);

--- a/src/core/ui.cpp
+++ b/src/core/ui.cpp
@@ -17,7 +17,7 @@ auto load_pixel_font_atlas() -> font_atlas
     font_atlas atlas;
     atlas.texture = std::make_unique<texture_png>("res\\pixel_font.png");
     atlas.missing_char = { .position{24, 52}, .size{5, 6}, .bearing{0, -6}, .advance=6 };
-    atlas.height = 7;
+    atlas.height = 5;
     
     atlas.chars['A'] = { .position{0, 0}, .size={5, 7}, .bearing={0, -7}, .advance=6 };
     atlas.chars['B'] = { .position{6, 0}, .size={5, 7}, .bearing={0, -7}, .advance=6 };
@@ -343,28 +343,28 @@ bool ui_engine::button(
     const auto lerp_time = 0.1;
     
     auto colour = unhovered_colour;
-    auto extra_width = 0.0f;
+    auto extra_width = 0;
     if (data.is_clicked()) {
         colour = clicked_colour;
-        extra_width = 10.0f;
+        extra_width = 10;
     }
     else if (data.is_hovered()) {
         const auto t = std::clamp(data.time_hovered(d_time) / lerp_time, 0.0, 1.0);
         colour = sand::lerp(unhovered_colour, hovered_colour, t);
-        extra_width = sand::lerp(0.0f, 10.0f, t);
+        extra_width = sand::lerp(0, 10, t);
     }
     else if (d_time > lerp_time) { // Don't start the game looking hovered
         const auto t = std::clamp(data.time_unhovered(d_time) / lerp_time, 0.0, 1.0);
         colour = sand::lerp(hovered_colour, unhovered_colour, t);
-        extra_width = sand::lerp(10.0f, 0.0f, t);
+        extra_width = sand::lerp(10, 0, t);
     }
     
-    const auto quad = ui_graphics_quad{pos, (i32)std::trunc(width + extra_width), height, 0.0f, colour, 0, {0, 0}, {0, 0}};
+    const auto quad = ui_graphics_quad{pos, width + extra_width, height, 0.0f, colour, 0, {0, 0}, {0, 0}};
     d_quads.emplace_back(quad);
 
     if (!msg.empty()) {
         auto text_pos = pos;
-        text_pos.y += 301.0f;
+        text_pos.y += (height + d_atlas.height * scale) / 2;
         text(msg, text_pos, scale);
     }
     return data.clicked_this_frame;
@@ -375,7 +375,7 @@ void ui_engine::text(std::string_view message, glm::ivec2 pos, i32 size)
     constexpr auto colour = from_hex(0xd2dae2);
     for (char c : message) {
         const auto ch = d_atlas.get_character(c);
-        
+
         const auto quad = ui_graphics_quad{
             pos + (size * ch.bearing),
             size * ch.size.x,

--- a/src/core/ui.hpp
+++ b/src/core/ui.hpp
@@ -56,6 +56,7 @@ struct font_atlas
     std::unique_ptr<texture_png>        texture;
     std::unordered_map<char, character> chars;
     character                           missing_char;
+    i32                                 height; // height of an "a", used for centring
 
     auto get_character(char c) const -> const character&;
 };
@@ -66,9 +67,9 @@ struct font_atlas
 // together, but I still feel conflicted.
 struct ui_graphics_quad
 {
-    glm::vec2  top_left;
-    float      width;
-    float      height;
+    glm::ivec2 top_left;
+    int        width;
+    int        height;
     float      angle;
     glm::vec4  colour;
     int        use_texture;
@@ -149,8 +150,8 @@ public:
     bool on_event(const event& e);
 
     // Step 2: setup ui elements    
-    bool button(glm::vec2 pos, f32 width, f32 height, const widget_key& key = {});
-    void text(std::string_view message, glm::vec2 pos, f32 size);
+    bool button(std::string_view msg, glm::ivec2 pos, i32 width, i32 height, i32 scale, const widget_key& key = {});
+    void text(std::string_view message, glm::ivec2 pos, i32 size);
     
     // Step 3: draw
     void draw_frame(i32 screen_width, i32 screen_height, f64 dt);

--- a/src/core/ui.hpp
+++ b/src/core/ui.hpp
@@ -7,8 +7,39 @@
 
 #include <array>
 #include <unordered_map>
+#include <source_location>
 
 #include <glm/glm.hpp>
+
+namespace sand {
+
+class widget_key
+{
+    std::string_view d_file;
+    u64              d_line;
+    u64              d_column;
+
+public:
+    widget_key(std::source_location loc = std::source_location::current())
+        : d_file{loc.file_name()}
+        , d_line{loc.line()}
+        , d_column{loc.column()}
+    {}
+    auto operator<=>(const widget_key&) const = default;
+    auto operator==(const widget_key&) const -> bool = default;
+    auto hash() const -> std::size_t { return 1; }
+};
+
+}
+
+template<>
+struct std::hash<sand::widget_key>
+{
+    auto operator()(const sand::widget_key& wk) const -> std::size_t
+    {
+        return wk.hash();
+    }
+};
 
 namespace sand {
 
@@ -94,12 +125,12 @@ class ui_engine
     f64       d_time                 = 0.0;
     bool      d_capture_mouse        = false;
 
-    std::unordered_map<std::string_view, ui_logic_quad> d_data;
+    std::unordered_map<widget_key, ui_logic_quad> d_data;
 
     font_atlas d_atlas;
 
-    const ui_logic_quad& get_data(std::string_view name, glm::vec2 top_left, f32 width, f32 height) { 
-        auto& data = d_data[name];
+    const ui_logic_quad& get_data(const widget_key& key, glm::vec2 top_left, f32 width, f32 height) { 
+        auto& data = d_data[key];
         data.active = true; // keep this alive
         data.top_left = top_left;
         data.width = width;
@@ -118,7 +149,7 @@ public:
     bool on_event(const event& e);
 
     // Step 2: setup ui elements    
-    bool button(std::string_view name, glm::vec2 pos, f32 width, f32 height);
+    bool button(glm::vec2 pos, f32 width, f32 height, const widget_key& key = {});
     void text(std::string_view message, glm::vec2 pos, f32 size);
     
     // Step 3: draw

--- a/src/core/ui.hpp
+++ b/src/core/ui.hpp
@@ -59,6 +59,7 @@ struct font_atlas
     i32                                 height; // height of an "a", used for centring
 
     auto get_character(char c) const -> const character&;
+    auto length_of(std::string_view message) -> i32;
 };
 
 // This is just a copy of quad_instance from the shape_renderer, should

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -58,17 +58,18 @@ auto scene_main_menu(sand::window& window) -> next_state
             return next_state::exit;
         }
 
-        ui.text("Lorem ipsum dolor sit amet, consectetur adipiscing elit,", {500, 200}, scale);
-        ui.text("sed do eiusmod tempor incididunt ut labore et dolore magna", {500, 200 + 1 * 11 * scale}, scale);
-        ui.text("aliqua. Ut enim ad minim veniam, quis nostrud exercitation", {500, 200 + 2 * 11 * scale}, scale);
-        ui.text("ullamco laboris nisi ut aliquip ex ea commodo consequat.", {500, 200 + 3 * 11 * scale}, scale);
-        ui.text("Duis aute irure dolor in reprehenderit in voluptate velit", {500, 200 + 4 * 11 * scale}, scale);
-        ui.text("esse cillum dolore eu fugiat nulla pariatur. Excepteur", {500, 200 + 5 * 11 * scale}, scale);
-        ui.text("sint occaecat cupidatat non proident, sunt in culpa", {500, 200 + 6 * 11 * scale}, scale);
-        ui.text("qui officia deserunt mollit anim id est laborum.", {500, 200 + 7 * 11 * scale}, scale);
-
-        ui.text("ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz", {100, 600}, scale);
-        ui.text("0123456789 () {} [] ^ < > - _ = + ! ? : ; . , @ % $ / \\ \" ' # ~ & | `", {100, 600 + 1 * 11 * scale}, scale);
+        const auto para_left = 100;
+        const auto para_top = 300;
+        ui.text("Lorem ipsum dolor sit amet, consectetur adipiscing elit,", {para_left, para_top}, scale);
+        ui.text("sed do eiusmod tempor incididunt ut labore et dolore magna", {para_left, para_top + 1 * 11 * scale}, scale);
+        ui.text("aliqua. Ut enim ad minim veniam, quis nostrud exercitation", {para_left, para_top + 2 * 11 * scale}, scale);
+        ui.text("ullamco laboris nisi ut aliquip ex ea commodo consequat.", {para_left, para_top + 3 * 11 * scale}, scale);
+        ui.text("Duis aute irure dolor in reprehenderit in voluptate velit", {para_left, para_top + 4 * 11 * scale}, scale);
+        ui.text("esse cillum dolore eu fugiat nulla pariatur. Excepteur", {para_left, para_top + 5 * 11 * scale}, scale);
+        ui.text("sint occaecat cupidatat non proident, sunt in culpa", {para_left, para_top + 6 * 11 * scale}, scale);
+        ui.text("qui officia deserunt mollit anim id est laborum.", {para_left, para_top + 7 * 11 * scale}, scale);
+        ui.text("ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz", {para_left, para_top + 8 * 11 * scale}, scale);
+        ui.text("0123456789 () {} [] ^ < > - _ = + ! ? : ; . , @ % $ / \\ \" ' # ~ & | `", {para_left, para_top + 9 * 11 * scale}, scale);
 
         ui.draw_frame(window.width(), window.height(), dt);
         window.end_frame();

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -44,13 +44,16 @@ auto scene_main_menu(sand::window& window) -> next_state
         }
         
         const auto scale = 3.0f;
+        const auto button_width = 200;
+        const auto button_height = 50;
+        const auto button_left = (window.width() - button_width) / 2;
 
-        if (ui.button("Start Game", {100, 100}, 200, 50, scale)) {
+        if (ui.button("Start Game", {button_left, 100}, button_width, button_height, scale)) {
             std::print("loading level!\n");
             return next_state::level;
         }
 
-        if (ui.button("Exit", {100, 160}, 200, 50, scale)) {
+        if (ui.button("Exit", {button_left, 160}, button_width, button_height, scale)) {
             std::print("exiting!\n");
             return next_state::exit;
         }

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -28,7 +28,6 @@ auto scene_main_menu(sand::window& window) -> next_state
     using namespace sand;
     auto timer           = sand::timer{};
     auto ui              = sand::ui_engine{};
-    auto mouse_pos       = glm::vec2{0, 0};
 
     constexpr auto clear_colour = from_hex(0x222f3e);
 
@@ -38,9 +37,6 @@ auto scene_main_menu(sand::window& window) -> next_state
 
         for (const auto event : window.events()) {
             ui.on_event(event);
-            if (auto e = event.get_if<mouse_moved_event>()) {
-                mouse_pos = e->pos;
-            }
         }
         
         const auto scale = 3.0f;

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -28,6 +28,7 @@ auto scene_main_menu(sand::window& window) -> next_state
     using namespace sand;
     auto timer           = sand::timer{};
     auto ui              = sand::ui_engine{};
+    auto mouse_pos       = glm::vec2{0, 0};
 
     constexpr auto clear_colour = from_hex(0x3d3d3d);
 
@@ -37,21 +38,24 @@ auto scene_main_menu(sand::window& window) -> next_state
 
         for (const auto event : window.events()) {
             ui.on_event(event);
+            if (auto e = event.get_if<mouse_moved_event>()) {
+                mouse_pos = e->pos;
+            }
         }
         
         const auto scale = 3.0f;
 
-        ui.text("Start Game", {215, 200}, scale);
-        if (ui.button({100, 100}, 100, 100)) {
+        if (ui.button("Start Game", {100, 100}, 100, 100, scale)) {
             std::print("loading level!\n");
             return next_state::level;
         }
 
-        ui.text("Exit", {215, 350}, scale);
-        if (ui.button({100, 250}, 100, 100)) {
+        if (ui.button("Exit", {100, 250}, 100, 100, scale)) {
             std::print("exiting!\n");
             return next_state::exit;
         }
+
+        ui.text("Start Game", mouse_pos, scale);
 
         ui.text("Lorem ipsum dolor sit amet, consectetur adipiscing elit,", {500, 200}, scale);
         ui.text("sed do eiusmod tempor incididunt ut labore et dolore magna", {500, 200 + 1 * 11 * scale}, scale);

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -30,7 +30,7 @@ auto scene_main_menu(sand::window& window) -> next_state
     auto ui              = sand::ui_engine{};
     auto mouse_pos       = glm::vec2{0, 0};
 
-    constexpr auto clear_colour = from_hex(0x3d3d3d);
+    constexpr auto clear_colour = from_hex(0x222f3e);
 
     while (window.is_running()) {
         const double dt = timer.on_update();
@@ -45,17 +45,15 @@ auto scene_main_menu(sand::window& window) -> next_state
         
         const auto scale = 3.0f;
 
-        if (ui.button("Start Game", {100, 100}, 100, 100, scale)) {
+        if (ui.button("Start Game", {100, 100}, 200, 50, scale)) {
             std::print("loading level!\n");
             return next_state::level;
         }
 
-        if (ui.button("Exit", {100, 250}, 100, 100, scale)) {
+        if (ui.button("Exit", {100, 160}, 200, 50, scale)) {
             std::print("exiting!\n");
             return next_state::exit;
         }
-
-        ui.text("Start Game", mouse_pos, scale);
 
         ui.text("Lorem ipsum dolor sit amet, consectetur adipiscing elit,", {500, 200}, scale);
         ui.text("sed do eiusmod tempor incididunt ut labore et dolore magna", {500, 200 + 1 * 11 * scale}, scale);

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -42,13 +42,13 @@ auto scene_main_menu(sand::window& window) -> next_state
         const auto scale = 3.0f;
 
         ui.text("Start Game", {215, 200}, scale);
-        if (ui.button("button1", {100, 100}, 100, 100)) {
+        if (ui.button({100, 100}, 100, 100)) {
             std::print("loading level!\n");
             return next_state::level;
         }
 
         ui.text("Exit", {215, 350}, scale);
-        if (ui.button("button2", {100, 250}, 100, 100)) {
+        if (ui.button({100, 250}, 100, 100)) {
             std::print("exiting!\n");
             return next_state::exit;
         }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7daf7387-caf2-4487-8fd4-bf172ce21fa1)
* Buttons now show the text given in the code.
* The name of the button is no longer used as a key in the map; instead each call passes an instances of `widget_key` built from a `std::source_location`, as the code never changes, so this gives each button a unique value. I'm not super keen on having a default function param that you should never pass, but that is better than potentially hitting a hash collision. I might see how `ImGui` does this.
* All values related to ui rendering now use `i32` rather `f32` since we can only handle integer coords of pixels anyway. Using floats was giving some weird artifacts while rendering.