### PR TITLE
Clean up the Fixed Time Step

### DIFF
--- a/src/core/entity.cpp
+++ b/src/core/entity.cpp
@@ -9,7 +9,7 @@ namespace {
 static constexpr auto player_id = 1;
 static constexpr auto enemy_id = 2;
 
-auto update_player(entity& e, const input& in) -> void
+auto update_player(entity& e, const input& in, double dt) -> void
 {
     const bool on_ground = !e.floors.empty();
     const bool can_move_left = e.num_left_contacts == 0;
@@ -53,7 +53,7 @@ auto update_player(entity& e, const input& in) -> void
     }
 }
 
-auto update_enemy(entity& e, const input& in) -> void
+auto update_enemy(entity& e, const input& in, double dt) -> void
 {
     for (const auto curr : e.nearby_entities) {
         const auto user_data = curr->GetUserData();
@@ -270,14 +270,14 @@ auto make_enemy(b2World& world, pixel_pos position) -> entity
     return e;
 }
 
-auto update_entity(entity& e, const input& in) -> void
+auto update_entity(entity& e, const input& in, double dt) -> void
 {
     switch (e.type) {
         case entity_type::player: {
-            update_player(e, in);
+            update_player(e, in, dt);
         } break;
         case entity_type::enemy: {
-            update_enemy(e, in);
+            update_enemy(e, in, dt);
         } break;
     }
 }

--- a/src/core/entity.hpp
+++ b/src/core/entity.hpp
@@ -55,7 +55,8 @@ struct entity
 
 auto make_player(b2World& world, pixel_pos position) -> entity;
 auto make_enemy(b2World& world, pixel_pos position) -> entity;
-auto update_entity(entity& e, const input& in, double dt) -> void;
+auto update_entity(entity& e, const input& in) -> void;
+auto entity_handle_event(entity& e, const event& ev) -> void;
 auto respawn_entity(entity& e) -> void;
 auto entity_centre(const entity& e) -> glm::vec2;
 

--- a/src/core/entity.hpp
+++ b/src/core/entity.hpp
@@ -55,7 +55,7 @@ struct entity
 
 auto make_player(b2World& world, pixel_pos position) -> entity;
 auto make_enemy(b2World& world, pixel_pos position) -> entity;
-auto update_entity(entity& e, const input& in) -> void;
+auto update_entity(entity& e, const input& in, double dt) -> void;
 auto respawn_entity(entity& e) -> void;
 auto entity_centre(const entity& e) -> glm::vec2;
 

--- a/src/core/event.hpp
+++ b/src/core/event.hpp
@@ -60,11 +60,11 @@ struct mouse_released_event {
 };
 
 struct mouse_moved_event {
-	glm::vec2 pos;
+	glm::ivec2 pos;
 };
 
 struct mouse_scrolled_event {
-	glm::vec2 offset;
+	glm::ivec2 offset;
 };
 
 // WINDOW EVENTS

--- a/src/core/renderer.cpp
+++ b/src/core/renderer.cpp
@@ -65,7 +65,6 @@ renderer::renderer(i32 width, i32 height)
     , d_vbo{0}
     , d_ebo{0}
     , d_texture{width, height}
-    , d_texture_data{}
     , d_shader{vertex_shader, fragment_shader}
 {
     const f32 vertices[] = {0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f};
@@ -112,6 +111,8 @@ auto renderer::update(const level& world) -> void
         from_hex(0xf6e58d), from_hex(0xf9ca24)
     };
 
+    glm::vec4 data[config::chunk_size * config::chunk_size] = {};
+
     for (i32 cx = 0; cx != world.pixels.width_in_chunks(); ++cx) {
         for (i32 cy = 0; cy != world.pixels.height_in_chunks(); ++cy) {
             const auto cpos = chunk_pos{cx, cy};
@@ -125,7 +126,7 @@ auto renderer::update(const level& world) -> void
                     const auto& pixel = world.pixels[world_coord];
                     const auto& props = properties(pixel);
                     
-                    auto& colour = d_texture_data[world_coord.x + d_texture.width() * world_coord.y];
+                    auto& colour = data[x + config::chunk_size * y];
                     if (pixel.flags[is_burning]) {
                         colour = sand::random_element(fire_colours);
                     }
@@ -146,9 +147,9 @@ auto renderer::update(const level& world) -> void
                     }
                 }
             }
+            d_texture.set_subdata(data, glm::ivec2{top_left}, config::chunk_size, config::chunk_size);
         }
     }
-    d_texture.set_data(d_texture_data);
     
 }
 
@@ -171,7 +172,6 @@ auto renderer::draw(const camera& camera) const -> void
 auto renderer::resize(u32 width, u32 height) -> void
 {
     d_texture.resize(width, height);
-    d_texture_data.resize(width * height);
 }
 
 }

--- a/src/core/renderer.cpp
+++ b/src/core/renderer.cpp
@@ -104,7 +104,7 @@ auto renderer::bind() const -> void
     d_shader.bind();
 }
 
-auto renderer::update(const level& world, const camera& camera) -> void
+auto renderer::update(const level& world) -> void
 {
     if (d_texture.width() != world.pixels.width_in_pixels() || d_texture.height() != world.pixels.height_in_pixels()) {
         resize(world.pixels.width_in_pixels(), world.pixels.height_in_pixels());
@@ -154,19 +154,21 @@ auto renderer::update(const level& world, const camera& camera) -> void
             }
         }
     }
+    d_texture.set_data(d_texture_data);
+    
+}
 
+auto renderer::draw(const camera& camera) const -> void
+{
+    d_shader.bind();
     d_shader.load_vec2("u_tex_offset", camera.top_left);
     d_shader.load_float("u_world_to_screen", camera.world_to_screen);
-
+    
     const auto projection = glm::ortho(
         0.0f, static_cast<float>(camera.screen_width), static_cast<float>(camera.screen_height), 0.0f
     );
     d_shader.load_mat4("u_proj_matrix", projection);
-    d_texture.set_data(d_texture_data);
-}
-
-auto renderer::draw() const -> void
-{
+    
     d_texture.bind();
     glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, nullptr);
 }

--- a/src/core/renderer.cpp
+++ b/src/core/renderer.cpp
@@ -98,12 +98,6 @@ renderer::~renderer()
     glDeleteVertexArrays(1, &d_vao);
 }
 
-auto renderer::bind() const -> void
-{
-    glBindVertexArray(d_vao);
-    d_shader.bind();
-}
-
 auto renderer::update(const level& world) -> void
 {
     if (d_texture.width() != world.pixels.width_in_pixels() || d_texture.height() != world.pixels.height_in_pixels()) {
@@ -160,6 +154,7 @@ auto renderer::update(const level& world) -> void
 
 auto renderer::draw(const camera& camera) const -> void
 {
+    glBindVertexArray(d_vao);
     d_shader.bind();
     d_shader.load_vec2("u_tex_offset", camera.top_left);
     d_shader.load_float("u_world_to_screen", camera.world_to_screen);

--- a/src/core/renderer.cpp
+++ b/src/core/renderer.cpp
@@ -118,14 +118,6 @@ auto renderer::update(const level& world, const camera& camera) -> void
         from_hex(0xf6e58d), from_hex(0xf9ca24)
     };
 
-    d_shader.load_vec2("u_tex_offset", camera.top_left);
-    d_shader.load_float("u_world_to_screen", camera.world_to_screen);
-
-    const auto projection = glm::ortho(
-        0.0f, static_cast<float>(camera.screen_width), static_cast<float>(camera.screen_height), 0.0f
-    );
-    d_shader.load_mat4("u_proj_matrix", projection);
-
     for (i32 cx = 0; cx != world.pixels.width_in_chunks(); ++cx) {
         for (i32 cy = 0; cy != world.pixels.height_in_chunks(); ++cy) {
             const auto cpos = chunk_pos{cx, cy};
@@ -163,11 +155,19 @@ auto renderer::update(const level& world, const camera& camera) -> void
         }
     }
 
+    d_shader.load_vec2("u_tex_offset", camera.top_left);
+    d_shader.load_float("u_world_to_screen", camera.world_to_screen);
+
+    const auto projection = glm::ortho(
+        0.0f, static_cast<float>(camera.screen_width), static_cast<float>(camera.screen_height), 0.0f
+    );
+    d_shader.load_mat4("u_proj_matrix", projection);
     d_texture.set_data(d_texture_data);
 }
 
 auto renderer::draw() const -> void
 {
+    d_texture.bind();
     glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, nullptr);
 }
 

--- a/src/core/renderer.hpp
+++ b/src/core/renderer.hpp
@@ -33,9 +33,9 @@ public:
 
     auto bind() const -> void;
 
-    auto update(const level& world, const camera& camera) -> void;
+    auto update(const level& world) -> void;
 
-    auto draw() const -> void;
+    auto draw(const camera& camera) const -> void;
 
     auto resize(u32 width, u32 height) -> void;
 };

--- a/src/core/renderer.hpp
+++ b/src/core/renderer.hpp
@@ -31,8 +31,6 @@ public:
     renderer(i32 width, i32 height);
     ~renderer();
 
-    auto bind() const -> void;
-
     auto update(const level& world) -> void;
 
     auto draw(const camera& camera) const -> void;

--- a/src/core/renderer.hpp
+++ b/src/core/renderer.hpp
@@ -20,7 +20,6 @@ class renderer
     u32 d_ebo;
 
     texture_dyn            d_texture;
-    std::vector<glm::vec4> d_texture_data;
 
     shader d_shader;
 

--- a/src/core/texture.cpp
+++ b/src/core/texture.cpp
@@ -26,6 +26,12 @@ auto texture_dyn::set_data(std::span<const glm::vec4> data) -> void
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, d_width, d_height, 0, GL_RGBA, GL_FLOAT, data.data());
 }
 
+auto texture_dyn::set_subdata(std::span<const glm::vec4> data, glm::ivec2 top_left, i32 width, i32 height) -> void
+{
+    assert(data.size() == width * height);
+    glTextureSubImage2D(d_texture, 0, top_left.x, top_left.y, width, height, GL_RGBA, GL_FLOAT, data.data());
+}
+
 auto texture_dyn::bind() const -> void
 {
     glBindTexture(GL_TEXTURE_2D, d_texture);

--- a/src/core/texture.hpp
+++ b/src/core/texture.hpp
@@ -22,6 +22,7 @@ public:
     ~texture_dyn();
 
     auto set_data(std::span<const glm::vec4> data) -> void;
+    auto set_subdata(std::span<const glm::vec4> data, glm::ivec2 top_left, i32 width, i32 height) -> void;
     auto bind() const -> void;
 
     auto resize(i32 width, i32 height) -> void;

--- a/src/core/utility.hpp
+++ b/src/core/utility.hpp
@@ -105,6 +105,12 @@ inline auto to_string(glm::vec2 v) -> std::string
     return std::format("glm::vec2{{{}, {}}}", v.x, v.y);
 }
 
+template <typename... Args>
+auto format_to(std::span<char> buffer, std::format_string<Args...> fmt, Args&&... args) -> std::string_view
+{
+    const auto result = std::format_to_n(buffer.data(), buffer.size(), fmt, std::forward<Args>(args)...);
+    return {buffer.data(), result.out};
+}
 
 template <typename T>
 concept has_to_string_member = requires(T obj)

--- a/src/core/window.cpp
+++ b/src/core/window.cpp
@@ -36,6 +36,7 @@ window::window(const char* name, int width, int height)
 
     glfwMakeContextCurrent(native_window);
     glfwSetWindowUserPointer(native_window, &d_data);
+    //glfwSwapInterval(10);
 
     // Initialise GLAD
     if (0 == gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {

--- a/src/core/window.cpp
+++ b/src/core/window.cpp
@@ -36,7 +36,7 @@ window::window(const char* name, int width, int height)
 
     glfwMakeContextCurrent(native_window);
     glfwSetWindowUserPointer(native_window, &d_data);
-    //glfwSwapInterval(10);
+    glfwSwapInterval(0);
 
     // Initialise GLAD
     if (0 == gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {

--- a/src/core/window.cpp
+++ b/src/core/window.cpp
@@ -36,7 +36,7 @@ window::window(const char* name, int width, int height)
 
     glfwMakeContextCurrent(native_window);
     glfwSetWindowUserPointer(native_window, &d_data);
-    glfwSwapInterval(0);
+    enable_vsync(true);
 
     // Initialise GLAD
     if (0 == gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {
@@ -172,6 +172,11 @@ bool window::is_running() const
 auto window::width() const -> int
 {
     return d_data.width; 
+}
+
+auto window::enable_vsync(bool enable) const -> void
+{
+    glfwSwapInterval(enable ? 1 : 0);
 }
 
 auto window::height() const -> int

--- a/src/core/window.cpp
+++ b/src/core/window.cpp
@@ -36,7 +36,7 @@ window::window(const char* name, int width, int height)
 
     glfwMakeContextCurrent(native_window);
     glfwSetWindowUserPointer(native_window, &d_data);
-    enable_vsync(true);
+    enable_vsync(false);
 
     // Initialise GLAD
     if (0 == gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {

--- a/src/core/window.hpp
+++ b/src/core/window.hpp
@@ -52,6 +52,8 @@ public:
     auto width() const -> int;
     auto height() const -> int;
 
+    auto enable_vsync(bool enable) const -> void;
+
     auto native_handle() -> GLFWwindow*;
 };
 

--- a/src/core/world.cpp
+++ b/src/core/world.cpp
@@ -486,7 +486,7 @@ auto world::step() -> void
         }
     }
     
-    d_physics.Step(sand::config::time_step, 8, 3);
+    d_physics.Step(sand::config::time_step, 10, 5);
 }
 
 level::level(i32 width, i32 height, const std::vector<pixel>& data, pixel_pos spawn)

--- a/src/editor.m.cpp
+++ b/src/editor.m.cpp
@@ -262,7 +262,6 @@ auto main() -> int
         ImGui::End();
 
         // Render and display the world
-        world_renderer.bind();
         if (updated) {
             world_renderer.update(*level);
         }

--- a/src/editor.m.cpp
+++ b/src/editor.m.cpp
@@ -124,9 +124,9 @@ auto main() -> int
             level->pixels.step();
         }
 
-        update_entity(level->player, input);
+        update_entity(level->player, input, dt);
         for (auto& e: level->entities) {
-            update_entity(e, input);
+            update_entity(e, input, dt);
         }
 
         const auto mouse_pos = pixel_at_mouse(input, camera);

--- a/src/editor.m.cpp
+++ b/src/editor.m.cpp
@@ -98,6 +98,10 @@ auto main() -> int
             }
 
             input.on_event(event);
+            entity_handle_event(level->player, event);
+            for (auto& e: level->entities) {
+                entity_handle_event(e, event);
+            }
 
             if (const auto e = event.get_if<sand::window_resize_event>()) {
                 camera.screen_width = e->width;
@@ -124,9 +128,9 @@ auto main() -> int
             level->pixels.step();
         }
 
-        update_entity(level->player, input, dt);
+        update_entity(level->player, input);
         for (auto& e: level->entities) {
-            update_entity(e, input, dt);
+            update_entity(e, input);
         }
 
         const auto mouse_pos = pixel_at_mouse(input, camera);

--- a/src/editor.m.cpp
+++ b/src/editor.m.cpp
@@ -260,9 +260,9 @@ auto main() -> int
         // Render and display the world
         world_renderer.bind();
         if (updated) {
-            world_renderer.update(*level, camera);
+            world_renderer.update(*level);
         }
-        world_renderer.draw();
+        world_renderer.draw(camera);
 
         shape_renderer.begin_frame(camera);
 

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -29,6 +29,7 @@ auto scene_main_menu(sand::window& window) -> next_state
     using namespace sand;
     auto timer           = sand::timer{};
     auto ui              = sand::ui_engine{};
+    char frame_rate_str[64];
 
     constexpr auto clear_colour = from_hex(0x222f3e);
 
@@ -69,6 +70,10 @@ auto scene_main_menu(sand::window& window) -> next_state
         ui.text("0123456789 () {} [] ^ < > - _ = + ! ? : ; . , @ % $ / \\ \" ' # ~ & | `", {para_left, para_top + 9 * 11 * scale}, scale);
 
         ui.draw_frame(window.width(), window.height(), dt);
+
+        const auto frame_rate = std::format_to_n(frame_rate_str, 64, "{}", timer.frame_rate());
+        const auto frame_rate_msg = std::string_view{frame_rate_str, frame_rate.out};
+        ui.text(frame_rate_msg, {0, 21}, 3);
         window.end_frame();
     }
 

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -30,8 +30,6 @@ auto scene_main_menu(sand::window& window) -> next_state
     auto timer           = sand::timer{};
     auto ui              = sand::ui_engine{};
 
-    std::array<char, 64> frame_rate_buf = {};
-
     constexpr auto clear_colour = from_hex(0x222f3e);
 
     while (window.is_running()) {
@@ -77,7 +75,8 @@ auto scene_main_menu(sand::window& window) -> next_state
         ui.text("ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz", {para_left, para_top + 8 * 11 * scale}, scale);
         ui.text("0123456789 () {} [] ^ < > - _ = + ! ? : ; . , @ % $ / \\ \" ' # ~ & | `", {para_left, para_top + 9 * 11 * scale}, scale);
 
-        ui.text(sand::format_to(frame_rate_buf, "{}", timer.frame_rate()), {0, 21}, 3);
+        std::array<char, 8> buf = {};
+        ui.text(sand::format_to(buf, "{}", timer.frame_rate()), {0, 21}, 3);
         ui.draw_frame(window.width(), window.height(), dt);
         window.end_frame();
     }
@@ -97,19 +96,18 @@ auto scene_level(sand::window& window) -> next_state
     auto debug_renderer  = sand::physics_debug_draw{&shape_renderer};
     auto ui              = sand::ui_engine{};
 
-    std::array<char, 64> frame_rate_buf = {};
-
+    
     const auto player_pos = glm::ivec2{entity_centre(level->player) + glm::vec2{200, 0}};
     auto other_entity = make_enemy(level->pixels.physics(), pixel_pos::from_ivec2(player_pos));
     level->entities.push_back(other_entity);
-
+    
     auto camera = sand::camera{
         .top_left = {0, 0},
         .screen_width = window.width(),
         .screen_height = window.height(),
         .world_to_screen = window.height() / 210.0f
     };
-
+    
     while (window.is_running()) {
         const double dt = timer.on_update();
         window.begin_frame();
@@ -144,23 +142,23 @@ auto scene_level(sand::window& window) -> next_state
             }
             level->pixels.step();
         }
-
+        
         const auto desired_top_left = entity_centre(level->player) - sand::dimensions(camera) / (2.0f * camera.world_to_screen);
         if (desired_top_left != camera.top_left) {
             const auto diff = desired_top_left - camera.top_left;
             camera.top_left += (float)dt * 3 * diff;
-
+            
             // Clamp the camera to the world, don't allow players to see the void
             const auto camera_dimensions_world_space = sand::dimensions(camera) / camera.world_to_screen;
             camera.top_left.x = std::clamp(camera.top_left.x, 0.0f, (float)level->pixels.width_in_pixels() - camera_dimensions_world_space.x);
             camera.top_left.y = std::clamp(camera.top_left.y, 0.0f, (float)level->pixels.height_in_pixels() - camera_dimensions_world_space.y);
         }
-
+        
         if (updated) {
             world_renderer.update(*level);
         }
         world_renderer.draw(camera);
-
+        
         // TODO: Replace with actual sprite data
         shape_renderer.begin_frame(camera);      
         shape_renderer.draw_circle(entity_centre(level->player), {1.0, 1.0, 0.0, 1.0}, 3);
@@ -170,8 +168,9 @@ auto scene_level(sand::window& window) -> next_state
         level->pixels.physics().SetDebugDraw(&debug_renderer);
         level->pixels.physics().DebugDraw();
         shape_renderer.end_frame();
-
-        ui.text(sand::format_to(frame_rate_buf, "{}", timer.frame_rate()), {0, 21}, 3);
+        
+        std::array<char, 8> buf = {};
+        ui.text(sand::format_to(buf, "{}", timer.frame_rate()), {0, 21}, 3);
         ui.draw_frame(window.width(), window.height(), dt);
 
         window.end_frame();

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -124,6 +124,10 @@ auto scene_level(sand::window& window) -> next_state
         while (accumulator > sand::config::time_step) {
             accumulator -= sand::config::time_step;
             updated = true;
+            update_entity(level->player, input, dt);
+            for (auto& e : level->entities) {
+                update_entity(e, input, dt);
+            }
             level->pixels.step();
         }
 
@@ -138,13 +142,8 @@ auto scene_level(sand::window& window) -> next_state
             camera.top_left.y = std::clamp(camera.top_left.y, 0.0f, (float)level->pixels.height_in_pixels() - camera_dimensions_world_space.y);
         }
 
-        update_entity(level->player, input, dt);
-        for (auto& e : level->entities) {
-            update_entity(e, input, dt);
-        }
-
         world_renderer.bind();
-        if (updated) {
+        if (updated || input.is_down(keyboard::R)) {
             world_renderer.update(*level, camera);
         }
         world_renderer.draw();

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -107,6 +107,10 @@ auto scene_level(sand::window& window) -> next_state
         
         for (const auto event : window.events()) {
             input.on_event(event);
+            entity_handle_event(level->player, event);
+            for (auto& e: level->entities) {
+                entity_handle_event(e, event);
+            }
             
             if (const auto e = event.get_if<sand::window_resize_event>()) {
                 camera.screen_width = e->width;
@@ -124,9 +128,9 @@ auto scene_level(sand::window& window) -> next_state
         while (accumulator > sand::config::time_step) {
             accumulator -= sand::config::time_step;
             updated = true;
-            update_entity(level->player, input, dt);
+            update_entity(level->player, input);
             for (auto& e : level->entities) {
-                update_entity(e, input, dt);
+                update_entity(e, input);
             }
             level->pixels.step();
         }

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -144,9 +144,9 @@ auto scene_level(sand::window& window) -> next_state
 
         world_renderer.bind();
         if (updated || input.is_down(keyboard::R)) {
-            world_renderer.update(*level, camera);
+            world_renderer.update(*level);
         }
-        world_renderer.draw();
+        world_renderer.draw(camera);
 
         // TODO: Replace with actual sprite data
         shape_renderer.begin_frame(camera);      

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -56,6 +56,13 @@ auto scene_main_menu(sand::window& window) -> next_state
             return next_state::exit;
         }
 
+        if (ui.button("Enable Vsync", {10, 50}, button_width, button_height, scale)) {
+            window.enable_vsync(true);
+        }
+        if (ui.button("Disable Vsync", {10, 110}, button_width, button_height, scale)) {
+            window.enable_vsync(false);
+        }
+
         const auto para_left = 100;
         const auto para_top = 300;
         ui.text("Lorem ipsum dolor sit amet, consectetur adipiscing elit,", {para_left, para_top}, scale);
@@ -69,11 +76,11 @@ auto scene_main_menu(sand::window& window) -> next_state
         ui.text("ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz", {para_left, para_top + 8 * 11 * scale}, scale);
         ui.text("0123456789 () {} [] ^ < > - _ = + ! ? : ; . , @ % $ / \\ \" ' # ~ & | `", {para_left, para_top + 9 * 11 * scale}, scale);
 
-        ui.draw_frame(window.width(), window.height(), dt);
-
+        
         const auto frame_rate = std::format_to_n(frame_rate_str, 64, "{}", timer.frame_rate());
         const auto frame_rate_msg = std::string_view{frame_rate_str, frame_rate.out};
         ui.text(frame_rate_msg, {0, 21}, 3);
+        ui.draw_frame(window.width(), window.height(), dt);
         window.end_frame();
     }
 

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -29,7 +29,8 @@ auto scene_main_menu(sand::window& window) -> next_state
     using namespace sand;
     auto timer           = sand::timer{};
     auto ui              = sand::ui_engine{};
-    char frame_rate_str[64];
+
+    std::array<char, 64> frame_rate_buf = {};
 
     constexpr auto clear_colour = from_hex(0x222f3e);
 
@@ -76,10 +77,7 @@ auto scene_main_menu(sand::window& window) -> next_state
         ui.text("ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz", {para_left, para_top + 8 * 11 * scale}, scale);
         ui.text("0123456789 () {} [] ^ < > - _ = + ! ? : ; . , @ % $ / \\ \" ' # ~ & | `", {para_left, para_top + 9 * 11 * scale}, scale);
 
-        
-        const auto frame_rate = std::format_to_n(frame_rate_str, 64, "{}", timer.frame_rate());
-        const auto frame_rate_msg = std::string_view{frame_rate_str, frame_rate.out};
-        ui.text(frame_rate_msg, {0, 21}, 3);
+        ui.text(sand::format_to(frame_rate_buf, "{}", timer.frame_rate()), {0, 21}, 3);
         ui.draw_frame(window.width(), window.height(), dt);
         window.end_frame();
     }
@@ -99,7 +97,7 @@ auto scene_level(sand::window& window) -> next_state
     auto debug_renderer  = sand::physics_debug_draw{&shape_renderer};
     auto ui              = sand::ui_engine{};
 
-    char frame_rate_str[64];
+    std::array<char, 64> frame_rate_buf = {};
 
     const auto player_pos = glm::ivec2{entity_centre(level->player) + glm::vec2{200, 0}};
     auto other_entity = make_enemy(level->pixels.physics(), pixel_pos::from_ivec2(player_pos));
@@ -173,9 +171,7 @@ auto scene_level(sand::window& window) -> next_state
         level->pixels.physics().DebugDraw();
         shape_renderer.end_frame();
 
-        const auto frame_rate = std::format_to_n(frame_rate_str, 64, "{}", timer.frame_rate());
-        const auto frame_rate_msg = std::string_view{frame_rate_str, frame_rate.out};
-        ui.text(frame_rate_msg, {0, 21}, 3);
+        ui.text(sand::format_to(frame_rate_buf, "{}", timer.frame_rate()), {0, 21}, 3);
         ui.draw_frame(window.width(), window.height(), dt);
 
         window.end_frame();

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -146,8 +146,7 @@ auto scene_level(sand::window& window) -> next_state
             camera.top_left.y = std::clamp(camera.top_left.y, 0.0f, (float)level->pixels.height_in_pixels() - camera_dimensions_world_space.y);
         }
 
-        world_renderer.bind();
-        if (updated || input.is_down(keyboard::R)) {
+        if (updated) {
             world_renderer.update(*level);
         }
         world_renderer.draw(camera);


### PR DESCRIPTION
* Corrected the fixed time step; entity updates should also only happen in the fixed time step. This means that the update step can easily miss inputs like jumps, so entities now have an `on_event` function that needs to be called to handle those properly.
* Disabled vsync, allowing for frame-rates much higher than 60 (my monitor refresh rate).
* Modify the renderer to only update parts of the world texture that actually changed, and stop storing a vector of pixel data as it isn't needed. This boots the game from 370fps to 470fps on my machine, so a good optimisation.
* Clean up the renderer calls and fix a bug; removed the `bind` function, and always bind the texture before drawing.
* Added buttons to the main screen for enabling/disabling vsync.
* Added `sand::format_to`, which is similar to `std::format`-like functions, but takes a buffer of chars and writes to that, returning a `std::string_view`.