### PR TITLE
Entity Component System

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.30)
+project(sandfall LANGUAGES CXX)
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
 set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS}")
-
-project(sandfall)
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.30)
 
 add_subdirectory(core)
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.30)
 
 find_package(glfw3 CONFIG REQUIRED)
 find_package(glad CONFIG REQUIRED)

--- a/src/core/entity.cpp
+++ b/src/core/entity.cpp
@@ -97,9 +97,12 @@ auto player_handle_event(registry& entities, entity e, const event& ev) -> void
 
 }
 
-void contact_listener::PreSolve(b2Contact* contact, const b2Manifold* impulse) 
+void contact_listener::PreSolve(b2Contact* contact, const b2Manifold*) 
 {
-    if (contact->GetFixtureA()->GetBody()->GetUserData().pointer == player_id || contact->GetFixtureB()->GetBody()->GetUserData().pointer == player_id) {
+    const auto a = static_cast<entity>(contact->GetFixtureA()->GetBody()->GetUserData().pointer);
+    const auto b = static_cast<entity>(contact->GetFixtureB()->GetBody()->GetUserData().pointer);
+
+    if (d_level->entities.has<player_component>(a) || d_level->entities.has<player_component>(b)) {
         contact->ResetFriction();
     }
 }

--- a/src/core/entity.cpp
+++ b/src/core/entity.cpp
@@ -110,6 +110,7 @@ void contact_listener::PreSolve(b2Contact* contact, const b2Manifold*)
 void contact_listener::begin_contact(b2Fixture* curr, b2Fixture* other)
 {
     const auto curr_entity = static_cast<entity>(curr->GetBody()->GetUserData().pointer);
+    const auto other_entity = static_cast<entity>(other->GetBody()->GetUserData().pointer);
     
     if (d_level->entities.has<player_component>(curr_entity) && !other->IsSensor()) {
         auto& comp = d_level->entities.get<player_component>(curr_entity);
@@ -125,7 +126,6 @@ void contact_listener::begin_contact(b2Fixture* curr, b2Fixture* other)
     }
     
     if (d_level->entities.has<proximity_component>(curr_entity)) {
-        const auto other_entity = static_cast<entity>(other->GetBody()->GetUserData().pointer);
         auto& comp = d_level->entities.get<proximity_component>(curr_entity);
         if (comp.proximity_sensor && curr == comp.proximity_sensor && d_level->entities.valid(other_entity)) {
             comp.nearby_entities.insert(other_entity);
@@ -136,6 +136,7 @@ void contact_listener::begin_contact(b2Fixture* curr, b2Fixture* other)
 void contact_listener::end_contact(b2Fixture* curr, b2Fixture* other)
 {
     const auto curr_entity = static_cast<entity>(curr->GetBody()->GetUserData().pointer);
+    const auto other_entity = static_cast<entity>(other->GetBody()->GetUserData().pointer);
     
     if (d_level->entities.has<player_component>(curr_entity) && !other->IsSensor()) {
         auto& comp = d_level->entities.get<player_component>(curr_entity);
@@ -151,7 +152,6 @@ void contact_listener::end_contact(b2Fixture* curr, b2Fixture* other)
     }
     
     if (d_level->entities.has<proximity_component>(curr_entity)) {
-        const auto other_entity = static_cast<entity>(other->GetBody()->GetUserData().pointer);
         auto& comp = d_level->entities.get<proximity_component>(curr_entity);
         if (comp.proximity_sensor && curr == comp.proximity_sensor && d_level->entities.valid(other_entity)) {
             comp.nearby_entities.erase(other_entity);

--- a/src/core/entity.cpp
+++ b/src/core/entity.cpp
@@ -51,9 +51,9 @@ auto update_player(registry& entities, entity e, const input& in) -> void
 
 auto update_enemy(registry& entities, entity e) -> void
 {
-    if (entities.has<proximity_component>(e)) {
-        auto [body_comp, enemy_comp, prox_comp] = entities.get_all<body_component, enemy_component, proximity_component>(e);
-        for (const auto curr : prox_comp.nearby_entities) {
+    if (entities.has<enemy_component>(e)) {
+        auto [body_comp, enemy_comp] = entities.get_all<body_component, enemy_component>(e);
+        for (const auto curr : enemy_comp.nearby_entities) {
             if (entities.has<player_component>(curr)) {
                 auto& curr_body_comp = entities.get<body_component>(curr);
                 const auto pos = physics_to_pixel(curr_body_comp.body->GetPosition());
@@ -125,8 +125,8 @@ void contact_listener::begin_contact(b2Fixture* curr, b2Fixture* other)
         }
     }
     
-    if (d_level->entities.has<proximity_component>(curr_entity)) {
-        auto& comp = d_level->entities.get<proximity_component>(curr_entity);
+    if (d_level->entities.has<enemy_component>(curr_entity)) {
+        auto& comp = d_level->entities.get<enemy_component>(curr_entity);
         if (comp.proximity_sensor && curr == comp.proximity_sensor && d_level->entities.valid(other_entity)) {
             comp.nearby_entities.insert(other_entity);
         }
@@ -151,8 +151,8 @@ void contact_listener::end_contact(b2Fixture* curr, b2Fixture* other)
         }
     }
     
-    if (d_level->entities.has<proximity_component>(curr_entity)) {
-        auto& comp = d_level->entities.get<proximity_component>(curr_entity);
+    if (d_level->entities.has<enemy_component>(curr_entity)) {
+        auto& comp = d_level->entities.get<enemy_component>(curr_entity);
         if (comp.proximity_sensor && curr == comp.proximity_sensor && d_level->entities.valid(other_entity)) {
             comp.nearby_entities.erase(other_entity);
         }
@@ -256,7 +256,6 @@ auto add_enemy(registry& entities, b2World& world, pixel_pos position) -> entity
     auto& body_comp = entities.emplace<body_component>(e);
     auto& enemy_comp = entities.emplace<enemy_component>(e);
     auto& life_comp = entities.emplace<life_component>(e);
-    auto& prox_comp = entities.emplace<proximity_component>(e);
 
     life_comp.spawn_point = position;
 
@@ -295,7 +294,7 @@ auto add_enemy(registry& entities, b2World& world, pixel_pos position) -> entity
         b2FixtureDef fixtureDef;
         fixtureDef.shape = &circleShape;
         fixtureDef.isSensor = true;
-        prox_comp.proximity_sensor = body_comp.body->CreateFixture(&fixtureDef);
+        enemy_comp.proximity_sensor = body_comp.body->CreateFixture(&fixtureDef);
     }
 
     return e;

--- a/src/core/entity.cpp
+++ b/src/core/entity.cpp
@@ -301,7 +301,7 @@ auto add_enemy(registry& entities, b2World& world, pixel_pos position) -> entity
     return e;
 }
 
-auto update_entities(registry& entities, const input& in) -> void
+auto ecs_on_update(registry& entities, const input& in) -> void
 {
     for (auto e : entities.view<player_component>()) {
         update_player(entities, e, in);
@@ -311,7 +311,7 @@ auto update_entities(registry& entities, const input& in) -> void
     }
 }
 
-auto entities_handle_event(registry& entities, const event& ev) -> void
+auto ecs_on_event(registry& entities, const event& ev) -> void
 {
     for (auto e : entities.view<body_component, player_component>()) {
         player_handle_event(entities, e, ev);
@@ -335,14 +335,6 @@ auto entity_centre(const registry& entities, entity e) -> glm::vec2
 {
     assert(entities.has<body_component>(e));
     return physics_to_pixel(entities.get<body_component>(e).body->GetPosition());
-}
-
-auto get_player(const registry& entities) -> entity
-{
-    for (auto e : entities.view<player_component>()) {
-        return e;
-    }
-    return apx::null;
 }
 
 }

--- a/src/core/entity.cpp
+++ b/src/core/entity.cpp
@@ -127,7 +127,7 @@ void contact_listener::BeginContact(b2Contact* contact)
     }
     if (d_level->entities.has<proximity_component>(ea)) {
         auto& comp = d_level->entities.get<proximity_component>(ea);
-        if (comp.proximity_sensor && a == comp.proximity_sensor) {
+        if (comp.proximity_sensor && a == comp.proximity_sensor && d_level->entities.valid(eb)) {
             comp.nearby_entities.insert(eb);
         }
     }
@@ -147,7 +147,7 @@ void contact_listener::BeginContact(b2Contact* contact)
     }
     if (d_level->entities.has<proximity_component>(eb)) {
         auto& comp = d_level->entities.get<proximity_component>(eb);
-        if (comp.proximity_sensor && b == comp.proximity_sensor) {
+        if (comp.proximity_sensor && b == comp.proximity_sensor && d_level->entities.valid(ea)) {
             comp.nearby_entities.insert(ea);
         }
     }
@@ -217,10 +217,10 @@ auto add_player(registry& entities, b2World& world, pixel_pos position) -> entit
     const auto pos = pixel_to_physics(position);
     bodyDef.position.Set(pos.x, pos.y);
     body_comp.body = world.CreateBody(&bodyDef);
+    body_comp.body->GetUserData().pointer = static_cast<std::uintptr_t>(e);
     b2MassData md;
     md.mass = 80;
     body_comp.body->SetMassData(&md);
-    body_comp.body->GetUserData().pointer = static_cast<std::uintptr_t>(e);
 
     // Set up main body fixture
     {
@@ -294,10 +294,10 @@ auto add_enemy(registry& entities, b2World& world, pixel_pos position) -> entity
     const auto pos = pixel_to_physics(position);
     bodyDef.position.Set(pos.x, pos.y);
     body_comp.body = world.CreateBody(&bodyDef);
+    body_comp.body->GetUserData().pointer = static_cast<std::uintptr_t>(e);
     b2MassData md;
     md.mass = 10;
     body_comp.body->SetMassData(&md);
-    body_comp.body->GetUserData().pointer = static_cast<std::uintptr_t>(e);
 
     // Set up main body fixture
     {

--- a/src/core/entity.cpp
+++ b/src/core/entity.cpp
@@ -41,6 +41,7 @@ auto update_player(entity& e, const input& in) -> void
 
     if (on_ground) {
         e.double_jump = true;
+        e.ground_pound = true;
     }
 }
 
@@ -61,7 +62,7 @@ auto player_handle_event(entity& e, const event& ev) -> void
 {
     const bool on_ground = !e.floors.empty();
     if (const auto inner = ev.get_if<keyboard_pressed_event>()) {
-        if (inner->key == keyboard::W) {
+        if (inner->key == keyboard::space) {
             if (on_ground || e.double_jump) {
                 if (!on_ground) {
                     e.double_jump = false;
@@ -69,6 +70,18 @@ auto player_handle_event(entity& e, const event& ev) -> void
                 float impulse = e.body->GetMass() * 7;
                 e.body->ApplyLinearImpulseToCenter(b2Vec2(0, -impulse), true);
             }
+        }
+        else if (inner->key == keyboard::S) {
+            if (e.ground_pound) {
+                e.ground_pound = false;
+                float impulse = e.body->GetMass() * 7;
+                e.body->ApplyLinearImpulseToCenter(b2Vec2(0, impulse), true);
+            }
+        }
+    }
+    else if (const auto inner = ev.get_if<mouse_pressed_event>()) {
+        if (inner->button == mouse::left) {
+            std::print("spawning bullet\n");
         }
     }
 }

--- a/src/core/entity.cpp
+++ b/src/core/entity.cpp
@@ -57,7 +57,7 @@ auto update_enemy(registry& entities, entity e) -> void
             if (entities.has<player_component>(curr)) {
                 auto& curr_body_comp = entities.get<body_component>(curr);
                 const auto pos = physics_to_pixel(curr_body_comp.body->GetPosition());
-                const auto self_pos = entity_centre(entities, e);
+                const auto self_pos = ecs_entity_centre(entities, e);
                 const auto dir = glm::normalize(pos - self_pos);
                 body_comp.body->ApplyLinearImpulseToCenter(pixel_to_physics(0.25f * dir), true);
             }
@@ -318,7 +318,7 @@ auto ecs_on_event(registry& entities, const event& ev) -> void
     }
 }
 
-auto respawn_entity(const registry& entities, entity e) -> void
+auto ecs_entity_respawn(const registry& entities, entity e) -> void
 {
     assert(entities.has<body_component>(e));
     assert(entities.has<life_component>(e));
@@ -331,7 +331,7 @@ auto respawn_entity(const registry& entities, entity e) -> void
     body_comp.body->SetAwake(true);
 }
 
-auto entity_centre(const registry& entities, entity e) -> glm::vec2
+auto ecs_entity_centre(const registry& entities, entity e) -> glm::vec2
 {
     assert(entities.has<body_component>(e));
     return physics_to_pixel(entities.get<body_component>(e).body->GetPosition());

--- a/src/core/entity.hpp
+++ b/src/core/entity.hpp
@@ -50,6 +50,8 @@ struct player_component
 
 struct enemy_component
 {
+    b2Fixture*                 proximity_sensor = nullptr;
+    std::unordered_set<entity> nearby_entities;
 };
 
 struct life_component
@@ -58,18 +60,11 @@ struct life_component
     i32       health      = 100;
 };
 
-struct proximity_component
-{
-    b2Fixture*                 proximity_sensor = nullptr;
-    std::unordered_set<entity> nearby_entities;
-};
-
 using registry = apx::registry<
     body_component,
     player_component,
     enemy_component,
-    life_component,
-    proximity_component
+    life_component
 >;
 
 

--- a/src/core/entity.hpp
+++ b/src/core/entity.hpp
@@ -17,6 +17,9 @@ class contact_listener : public b2ContactListener
 {
     level* d_level;
 
+    void begin_contact(b2Fixture* curr, b2Fixture* other);
+    void end_contact(b2Fixture* curr, b2Fixture* other);
+
 public:
     contact_listener(level* l) : d_level{l} {}
 

--- a/src/core/entity.hpp
+++ b/src/core/entity.hpp
@@ -47,6 +47,7 @@ struct entity
     std::unordered_set<b2Body*> nearby_entities;
 
     bool double_jump        = false;
+    bool ground_pound       = false;
     int  num_left_contacts  = 0;
     int  num_right_contacts = 0;
 

--- a/src/core/entity.hpp
+++ b/src/core/entity.hpp
@@ -75,10 +75,9 @@ using registry = apx::registry<
 
 auto add_player(registry& entities, b2World& world, pixel_pos position) -> entity;
 auto add_enemy(registry& entities, b2World& world, pixel_pos position) -> entity;
-auto update_entities(registry& entities, const input& in) -> void;
-auto entities_handle_event(registry& entities, const event& ev) -> void;
+auto ecs_on_update(registry& entities, const input& in) -> void;
+auto ecs_on_event(registry& entities, const event& ev) -> void;
 auto respawn_entity(const registry& entities, entity e) -> void;
 auto entity_centre(const registry& entities, entity e) -> glm::vec2;
-auto get_player(const registry& entities) -> entity;
 
 }

--- a/src/core/entity.hpp
+++ b/src/core/entity.hpp
@@ -10,6 +10,8 @@
 
 namespace sand {
 
+using entity = apx::entity;
+
 class level;
 class contact_listener : public b2ContactListener
 {
@@ -23,42 +25,57 @@ public:
     void EndContact(b2Contact* contact) override;
 };
 
-enum class entity_type
+struct body_component
 {
-    player,
-    enemy,
+    b2Body* body = nullptr;
+    b2Fixture* body_fixture = nullptr;
 };
 
-// Possibly will replace with an entity component system in the future,
-// but for now just a big bag of data will suffice
-struct entity
+struct player_component
 {
-    entity_type type;
-    pixel_pos  spawn_point  = {0, 0};
-
-    b2Body*    body         = nullptr;
-    b2Fixture* body_fixture = nullptr;
     b2Fixture* foot_sensor  = nullptr;
     b2Fixture* left_sensor  = nullptr;
     b2Fixture* right_sensor = nullptr;
-
-    // Used by the enemy AI to detect the player
-    b2Fixture*                  proximity_sensor = nullptr;
-    std::unordered_set<b2Body*> nearby_entities;
-
-    bool double_jump        = false;
-    bool ground_pound       = false;
-    int  num_left_contacts  = 0;
-    int  num_right_contacts = 0;
-
+    
     std::unordered_set<b2Fixture*> floors;
+    int num_left_contacts  = 0;
+    int num_right_contacts = 0;
+
+    bool double_jump = true;
+    bool ground_pound = true;
 };
 
-auto make_player(b2World& world, pixel_pos position) -> entity;
-auto make_enemy(b2World& world, pixel_pos position) -> entity;
-auto update_entity(entity& e, const input& in) -> void;
-auto entity_handle_event(entity& e, const event& ev) -> void;
-auto respawn_entity(entity& e) -> void;
-auto entity_centre(const entity& e) -> glm::vec2;
+struct enemy_component
+{
+};
+
+struct life_component
+{
+    pixel_pos spawn_point = {0, 0};
+    i32       health      = 100;
+};
+
+struct proximity_component
+{
+    b2Fixture*                 proximity_sensor = nullptr;
+    std::unordered_set<entity> nearby_entities;
+};
+
+using registry = apx::registry<
+    body_component,
+    player_component,
+    enemy_component,
+    life_component,
+    proximity_component
+>;
+
+
+auto add_player(registry& entities, b2World& world, pixel_pos position) -> entity;
+auto add_enemy(registry& entities, b2World& world, pixel_pos position) -> entity;
+auto update_entities(registry& entities, const input& in) -> void;
+auto entities_handle_event(registry& entities, const event& ev) -> void;
+auto respawn_entity(const registry& entities, entity e) -> void;
+auto entity_centre(const registry& entities, entity e) -> glm::vec2;
+auto get_player(const registry& entities) -> entity;
 
 }

--- a/src/core/entity.hpp
+++ b/src/core/entity.hpp
@@ -75,9 +75,10 @@ using registry = apx::registry<
 
 auto add_player(registry& entities, b2World& world, pixel_pos position) -> entity;
 auto add_enemy(registry& entities, b2World& world, pixel_pos position) -> entity;
+
 auto ecs_on_update(registry& entities, const input& in) -> void;
 auto ecs_on_event(registry& entities, const event& ev) -> void;
-auto respawn_entity(const registry& entities, entity e) -> void;
-auto entity_centre(const registry& entities, entity e) -> glm::vec2;
+auto ecs_entity_respawn(const registry& entities, entity e) -> void;
+auto ecs_entity_centre(const registry& entities, entity e) -> glm::vec2;
 
 }

--- a/src/core/event.hpp
+++ b/src/core/event.hpp
@@ -15,6 +15,7 @@ enum class mouse
 enum class keyboard
 {
 	A = 65, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
+	space     = 32,
 	escape    = 256,
 	enter     = 257,
 	tab       = 258,

--- a/src/core/update_rigid_bodies.cpp
+++ b/src/core/update_rigid_bodies.cpp
@@ -197,7 +197,9 @@ auto new_body(b2World& world) -> b2Body*
     b2BodyDef bodyDef;
     bodyDef.type = b2_staticBody;
     bodyDef.position.Set(0.0f, 0.0f);
-    return world.CreateBody(&bodyDef);
+    auto body = world.CreateBody(&bodyDef);
+    body->GetUserData().pointer = static_cast<std::uintptr_t>(apx::null);
+    return body;
 }
 
 auto flood_remove(chunk_static_pixels& pixels, glm::ivec2 offset) -> void

--- a/src/core/utility.hpp
+++ b/src/core/utility.hpp
@@ -66,11 +66,11 @@ auto random_unit() -> float; // Same as random_from_range(0.0f, 1.0f)
 
 consteval auto from_hex(int hex) -> glm::vec4
 {
-    const float blue = static_cast<float>(hex & 0xff) / 256.0f;
+    const auto blue = static_cast<float>(hex & 0xff) / 256.0f;
     hex /= 0x100;
-    const float green = static_cast<float>(hex & 0xff) / 256.0f;
+    const auto green = static_cast<float>(hex & 0xff) / 256.0f;
     hex /= 0x100;
-    const float red = static_cast<float>(hex & 0xff) / 256.0f;
+    const auto red = static_cast<float>(hex & 0xff) / 256.0f;
     return glm::vec4{red, green, blue, 1.0f};
 }
 

--- a/src/core/window.hpp
+++ b/src/core/window.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "event.hpp"
+#include "utility.hpp"
 
 #include <glm/glm.hpp>
 

--- a/src/core/world.cpp
+++ b/src/core/world.cpp
@@ -492,10 +492,10 @@ auto world::step() -> void
 level::level(i32 width, i32 height, const std::vector<pixel>& data, pixel_pos spawn)
     : pixels{width, height, data}
     , spawn_point{spawn}
-    , player{make_player(pixels.physics(), spawn)}
     , listener{this}
 {
     pixels.physics().SetContactListener(&listener);
+    add_player(entities, pixels.physics(), spawn);
 }
 
 }

--- a/src/core/world.cpp
+++ b/src/core/world.cpp
@@ -495,7 +495,7 @@ level::level(i32 width, i32 height, const std::vector<pixel>& data, pixel_pos sp
     , listener{this}
 {
     pixels.physics().SetContactListener(&listener);
-    add_player(entities, pixels.physics(), spawn);
+    player = add_player(entities, pixels.physics(), spawn);
 }
 
 }

--- a/src/core/world.hpp
+++ b/src/core/world.hpp
@@ -94,13 +94,10 @@ class world
 
 struct level
 {
-    world               pixels;
-    pixel_pos           spawn_point;
-
-    entity              player;
-    std::vector<entity> entities;
-    
-    contact_listener    listener;
+    world            pixels;
+    pixel_pos        spawn_point;
+    registry         entities;
+    contact_listener listener;
 
     level(i32 width, i32 height, const std::vector<pixel>& pixels, pixel_pos spawn);
 };

--- a/src/core/world.hpp
+++ b/src/core/world.hpp
@@ -97,6 +97,7 @@ struct level
     world            pixels;
     pixel_pos        spawn_point;
     registry         entities;
+    entity           player;
     contact_listener listener;
 
     level(i32 width, i32 height, const std::vector<pixel>& pixels, pixel_pos spawn);

--- a/src/editor.m.cpp
+++ b/src/editor.m.cpp
@@ -98,7 +98,7 @@ auto main() -> int
             }
 
             input.on_event(event);
-            entities_handle_event(level->entities, event);
+            ecs_on_event(level->entities, event);
 
             if (const auto e = event.get_if<sand::window_resize_event>()) {
                 camera.screen_width = e->width;
@@ -125,7 +125,7 @@ auto main() -> int
             level->pixels.step();
         }
 
-        update_entities(level->entities, input);
+        ecs_on_update(level->entities, input);
 
         const auto mouse_pos = pixel_at_mouse(input, camera);
         switch (editor.brush_type) {
@@ -180,8 +180,7 @@ auto main() -> int
                 ImGui::Text("  is_falling: n/a");
             }
 
-            const auto player = get_player(level->entities);
-            const auto num_floors = level->entities.get<player_component>(player).floors.size();
+            const auto num_floors = level->entities.get<player_component>(level->player).floors.size();
             ImGui::Text("Number of Floors: %d", num_floors);
             ImGui::Text("Events this frame: %zu", window.events().size());
             ImGui::Separator();
@@ -198,7 +197,7 @@ auto main() -> int
             ImGui::SliderInt("Spawn X", &level->spawn_point.x, 0, level->pixels.width_in_pixels());
             ImGui::SliderInt("Spawn Y", &level->spawn_point.y, 0, level->pixels.height_in_pixels());
             if (ImGui::Button("Respawn")) {
-                respawn_entity(level->entities, player);
+                respawn_entity(level->entities, level->player);
             }
             ImGui::Separator();
 
@@ -267,8 +266,7 @@ auto main() -> int
         shape_renderer.begin_frame(camera);
 
         // TODO: Replace with actual sprite data
-        auto player = get_player(level->entities);
-        shape_renderer.draw_circle(entity_centre(level->entities, player), {1.0, 1.0, 0.0, 1.0}, 3);
+        shape_renderer.draw_circle(entity_centre(level->entities, level->player), {1.0, 1.0, 0.0, 1.0}, 3);
 
         if (editor.show_physics) {
             level->pixels.physics().SetDebugDraw(&debug_draw);

--- a/src/editor.m.cpp
+++ b/src/editor.m.cpp
@@ -197,7 +197,7 @@ auto main() -> int
             ImGui::SliderInt("Spawn X", &level->spawn_point.x, 0, level->pixels.width_in_pixels());
             ImGui::SliderInt("Spawn Y", &level->spawn_point.y, 0, level->pixels.height_in_pixels());
             if (ImGui::Button("Respawn")) {
-                respawn_entity(level->entities, level->player);
+                ecs_entity_respawn(level->entities, level->player);
             }
             ImGui::Separator();
 
@@ -266,7 +266,7 @@ auto main() -> int
         shape_renderer.begin_frame(camera);
 
         // TODO: Replace with actual sprite data
-        shape_renderer.draw_circle(entity_centre(level->entities, level->player), {1.0, 1.0, 0.0, 1.0}, 3);
+        shape_renderer.draw_circle(ecs_entity_centre(level->entities, level->player), {1.0, 1.0, 0.0, 1.0}, 3);
 
         if (editor.show_physics) {
             level->pixels.physics().SetDebugDraw(&debug_draw);

--- a/src/editor.m.cpp
+++ b/src/editor.m.cpp
@@ -98,10 +98,7 @@ auto main() -> int
             }
 
             input.on_event(event);
-            entity_handle_event(level->player, event);
-            for (auto& e: level->entities) {
-                entity_handle_event(e, event);
-            }
+            entities_handle_event(level->entities, event);
 
             if (const auto e = event.get_if<sand::window_resize_event>()) {
                 camera.screen_width = e->width;
@@ -128,10 +125,7 @@ auto main() -> int
             level->pixels.step();
         }
 
-        update_entity(level->player, input);
-        for (auto& e: level->entities) {
-            update_entity(e, input);
-        }
+        update_entities(level->entities, input);
 
         const auto mouse_pos = pixel_at_mouse(input, camera);
         switch (editor.brush_type) {
@@ -185,7 +179,10 @@ auto main() -> int
                 ImGui::Text("  pixel power: n/a");
                 ImGui::Text("  is_falling: n/a");
             }
-            ImGui::Text("Number of Floors: %d", level->player.floors.size());
+
+            const auto player = get_player(level->entities);
+            const auto num_floors = level->entities.get<player_component>(player).floors.size();
+            ImGui::Text("Number of Floors: %d", num_floors);
             ImGui::Text("Events this frame: %zu", window.events().size());
             ImGui::Separator();
 
@@ -201,7 +198,7 @@ auto main() -> int
             ImGui::SliderInt("Spawn X", &level->spawn_point.x, 0, level->pixels.width_in_pixels());
             ImGui::SliderInt("Spawn Y", &level->spawn_point.y, 0, level->pixels.height_in_pixels());
             if (ImGui::Button("Respawn")) {
-                respawn_entity(level->player);
+                respawn_entity(level->entities, player);
             }
             ImGui::Separator();
 
@@ -270,7 +267,8 @@ auto main() -> int
         shape_renderer.begin_frame(camera);
 
         // TODO: Replace with actual sprite data
-        shape_renderer.draw_circle(entity_centre(level->player), {1.0, 1.0, 0.0, 1.0}, 3);
+        auto player = get_player(level->entities);
+        shape_renderer.draw_circle(entity_centre(level->entities, player), {1.0, 1.0, 0.0, 1.0}, 3);
 
         if (editor.show_physics) {
             level->pixels.physics().SetDebugDraw(&debug_draw);

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -112,18 +112,19 @@ auto scene_level(sand::window& window) -> next_state
         input.on_new_frame();
         
         for (const auto event : window.events()) {
-            input.on_event(event);
-            entities_handle_event(level->entities, event);
-            
-            if (const auto e = event.get_if<sand::window_resize_event>()) {
+            if (const auto e = event.get_if<sand::keyboard_pressed_event>()) {
+                if (e->key == keyboard::escape) {
+                    return next_state::main_menu;
+                }
+            }
+            else if (const auto e = event.get_if<sand::window_resize_event>()) {
                 camera.screen_width = e->width;
                 camera.screen_height = e->height;
                 camera.world_to_screen = e->height / 210.0f;
             }
-        }
-        
-        if (input.is_down_this_frame(keyboard::escape)) {
-            return next_state::main_menu;
+
+            input.on_event(event);
+            entities_handle_event(level->entities, event);
         }
         
         accumulator += dt;

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -95,10 +95,9 @@ auto scene_level(sand::window& window) -> next_state
     auto debug_renderer  = sand::physics_debug_draw{&shape_renderer};
     auto ui              = sand::ui_engine{};
 
-    
-    const auto player_pos = glm::ivec2{entity_centre(level->player) + glm::vec2{200, 0}};
-    auto other_entity = make_enemy(level->pixels.physics(), pixel_pos::from_ivec2(player_pos));
-    level->entities.push_back(other_entity);
+    const auto player = get_player(level->entities);
+    const auto player_pos = glm::ivec2{entity_centre(level->entities, player) + glm::vec2{200, 0}};
+    add_enemy(level->entities, level->pixels.physics(), pixel_pos::from_ivec2(player_pos));
     
     auto camera = sand::camera{
         .top_left = {0, 0},
@@ -114,10 +113,7 @@ auto scene_level(sand::window& window) -> next_state
         
         for (const auto event : window.events()) {
             input.on_event(event);
-            entity_handle_event(level->player, event);
-            for (auto& e: level->entities) {
-                entity_handle_event(e, event);
-            }
+            entities_handle_event(level->entities, event);
             
             if (const auto e = event.get_if<sand::window_resize_event>()) {
                 camera.screen_width = e->width;
@@ -135,14 +131,12 @@ auto scene_level(sand::window& window) -> next_state
         while (accumulator > sand::config::time_step) {
             accumulator -= sand::config::time_step;
             updated = true;
-            update_entity(level->player, input);
-            for (auto& e : level->entities) {
-                update_entity(e, input);
-            }
+            update_entities(level->entities, input);
             level->pixels.step();
         }
         
-        const auto desired_top_left = entity_centre(level->player) - sand::dimensions(camera) / (2.0f * camera.world_to_screen);
+        const auto player_entity = get_player(level->entities);
+        const auto desired_top_left = entity_centre(level->entities, player_entity) - sand::dimensions(camera) / (2.0f * camera.world_to_screen);
         if (desired_top_left != camera.top_left) {
             const auto diff = desired_top_left - camera.top_left;
             camera.top_left += (float)dt * 3 * diff;
@@ -160,12 +154,12 @@ auto scene_level(sand::window& window) -> next_state
         
         // TODO: Replace with actual sprite data
         shape_renderer.begin_frame(camera);      
-        shape_renderer.draw_circle(entity_centre(level->player), {1.0, 1.0, 0.0, 1.0}, 3);
-        for (const auto& e : level->entities) {
-            shape_renderer.draw_circle(entity_centre(e), {0.5, 1.0, 0.5, 1.0}, 2.5);
+        shape_renderer.draw_circle(entity_centre(level->entities, player_entity), {1.0, 1.0, 0.0, 1.0}, 3);
+        for (auto e : level->entities.all()) {
+            shape_renderer.draw_circle(entity_centre(level->entities, e), {0.5, 1.0, 0.5, 1.0}, 2.5);
         }
 
-        const auto centre = entity_centre(level->player);
+        const auto centre = entity_centre(level->entities, get_player(level->entities));
         const auto direction = glm::normalize(mouse_pos_world_space(input, camera) - centre);
         shape_renderer.draw_line(centre, centre + 10.0f * direction, {1, 1, 1, 1}, 2);
         level->pixels.physics().SetDebugDraw(&debug_renderer);

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -95,7 +95,7 @@ auto scene_level(sand::window& window) -> next_state
     auto debug_renderer  = sand::physics_debug_draw{&shape_renderer};
     auto ui              = sand::ui_engine{};
 
-    const auto player_pos = glm::ivec2{entity_centre(level->entities, level->player) + glm::vec2{200, 0}};
+    const auto player_pos = glm::ivec2{ecs_entity_centre(level->entities, level->player) + glm::vec2{200, 0}};
     add_enemy(level->entities, level->pixels.physics(), pixel_pos::from_ivec2(player_pos));
     
     auto camera = sand::camera{
@@ -135,7 +135,7 @@ auto scene_level(sand::window& window) -> next_state
             level->pixels.step();
         }
         
-        const auto desired_top_left = entity_centre(level->entities, level->player) - sand::dimensions(camera) / (2.0f * camera.world_to_screen);
+        const auto desired_top_left = ecs_entity_centre(level->entities, level->player) - sand::dimensions(camera) / (2.0f * camera.world_to_screen);
         if (desired_top_left != camera.top_left) {
             const auto diff = desired_top_left - camera.top_left;
             camera.top_left += (float)dt * 3 * diff;
@@ -153,12 +153,12 @@ auto scene_level(sand::window& window) -> next_state
         
         // TODO: Replace with actual sprite data
         shape_renderer.begin_frame(camera);      
-        shape_renderer.draw_circle(entity_centre(level->entities, level->player), {1.0, 1.0, 0.0, 1.0}, 3);
+        shape_renderer.draw_circle(ecs_entity_centre(level->entities, level->player), {1.0, 1.0, 0.0, 1.0}, 3);
         for (auto e : level->entities.all()) {
-            shape_renderer.draw_circle(entity_centre(level->entities, e), {0.5, 1.0, 0.5, 1.0}, 2.5);
+            shape_renderer.draw_circle(ecs_entity_centre(level->entities, e), {0.5, 1.0, 0.5, 1.0}, 2.5);
         }
 
-        const auto centre = entity_centre(level->entities, level->player);
+        const auto centre = ecs_entity_centre(level->entities, level->player);
         const auto direction = glm::normalize(mouse_pos_world_space(input, camera) - centre);
         shape_renderer.draw_line(centre, centre + 10.0f * direction, {1, 1, 1, 1}, 2);
         level->pixels.physics().SetDebugDraw(&debug_renderer);

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -164,7 +164,11 @@ auto scene_level(sand::window& window) -> next_state
         shape_renderer.draw_circle(entity_centre(level->player), {1.0, 1.0, 0.0, 1.0}, 3);
         for (const auto& e : level->entities) {
             shape_renderer.draw_circle(entity_centre(e), {0.5, 1.0, 0.5, 1.0}, 2.5);
-        }  
+        }
+
+        const auto centre = entity_centre(level->player);
+        const auto direction = glm::normalize(mouse_pos_world_space(input, camera) - centre);
+        shape_renderer.draw_line(centre, centre + 10.0f * direction, {1, 1, 1, 1}, 2);
         level->pixels.physics().SetDebugDraw(&debug_renderer);
         level->pixels.physics().DebugDraw();
         shape_renderer.end_frame();

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -13,7 +13,6 @@
 #include <glm/glm.hpp>
 #include <glm/gtx/norm.hpp>
 
-#include <memory>
 #include <format>
 #include <print>
 
@@ -27,8 +26,8 @@ enum class next_state
 auto scene_main_menu(sand::window& window) -> next_state
 {
     using namespace sand;
-    auto timer           = sand::timer{};
-    auto ui              = sand::ui_engine{};
+    auto timer = sand::timer{};
+    auto ui    = sand::ui_engine{};
 
     constexpr auto clear_colour = from_hex(0x222f3e);
 

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -95,8 +95,7 @@ auto scene_level(sand::window& window) -> next_state
     auto debug_renderer  = sand::physics_debug_draw{&shape_renderer};
     auto ui              = sand::ui_engine{};
 
-    const auto player = get_player(level->entities);
-    const auto player_pos = glm::ivec2{entity_centre(level->entities, player) + glm::vec2{200, 0}};
+    const auto player_pos = glm::ivec2{entity_centre(level->entities, level->player) + glm::vec2{200, 0}};
     add_enemy(level->entities, level->pixels.physics(), pixel_pos::from_ivec2(player_pos));
     
     auto camera = sand::camera{
@@ -124,7 +123,7 @@ auto scene_level(sand::window& window) -> next_state
             }
 
             input.on_event(event);
-            entities_handle_event(level->entities, event);
+            ecs_on_event(level->entities, event);
         }
         
         accumulator += dt;
@@ -132,12 +131,11 @@ auto scene_level(sand::window& window) -> next_state
         while (accumulator > sand::config::time_step) {
             accumulator -= sand::config::time_step;
             updated = true;
-            update_entities(level->entities, input);
+            ecs_on_update(level->entities, input);
             level->pixels.step();
         }
         
-        const auto player_entity = get_player(level->entities);
-        const auto desired_top_left = entity_centre(level->entities, player_entity) - sand::dimensions(camera) / (2.0f * camera.world_to_screen);
+        const auto desired_top_left = entity_centre(level->entities, level->player) - sand::dimensions(camera) / (2.0f * camera.world_to_screen);
         if (desired_top_left != camera.top_left) {
             const auto diff = desired_top_left - camera.top_left;
             camera.top_left += (float)dt * 3 * diff;
@@ -155,12 +153,12 @@ auto scene_level(sand::window& window) -> next_state
         
         // TODO: Replace with actual sprite data
         shape_renderer.begin_frame(camera);      
-        shape_renderer.draw_circle(entity_centre(level->entities, player_entity), {1.0, 1.0, 0.0, 1.0}, 3);
+        shape_renderer.draw_circle(entity_centre(level->entities, level->player), {1.0, 1.0, 0.0, 1.0}, 3);
         for (auto e : level->entities.all()) {
             shape_renderer.draw_circle(entity_centre(level->entities, e), {0.5, 1.0, 0.5, 1.0}, 2.5);
         }
 
-        const auto centre = entity_centre(level->entities, get_player(level->entities));
+        const auto centre = entity_centre(level->entities, level->player);
         const auto direction = glm::normalize(mouse_pos_world_space(input, camera) - centre);
         shape_renderer.draw_line(centre, centre + 10.0f * direction, {1, 1, 1, 1}, 2);
         level->pixels.physics().SetDebugDraw(&debug_renderer);


### PR DESCRIPTION
* Replace the `entity` class with an `apecs` entity component system.
* Overkill for now, but will be more useful when more entities are added.
* Currently, not all physics bodies have entities; the chunks and their rigid bodies for example. Maybe these should become entities? Seems like the natural way to attach data to some chunks but not others. We will see.
* The level structure is starting to get complicated again, it might be time for another refactor.