### PR TITLE
Make Air Transparent

### DIFF
--- a/imgui.ini
+++ b/imgui.ini
@@ -8,6 +8,6 @@ Size=476,528
 Collapsed=1
 
 [Window][Editor]
-Pos=1353,124
+Pos=845,69
 Size=411,604
 

--- a/imgui.ini
+++ b/imgui.ini
@@ -8,6 +8,6 @@ Size=476,528
 Collapsed=1
 
 [Window][Editor]
-Pos=829,67
+Pos=1353,124
 Size=411,604
 

--- a/src/core/pixel.cpp
+++ b/src/core/pixel.cpp
@@ -251,7 +251,7 @@ auto pixel::air() -> pixel
 {
     return pixel{
         .type = pixel_type::none,
-        .colour = from_hex(0x2C3A47)
+        .colour = {0.0f, 0.0f, 0.0f, 0.0f}
     };
 }
 

--- a/src/core/pixel.hpp
+++ b/src/core/pixel.hpp
@@ -102,28 +102,28 @@ struct pixel
     // For power sources, it is a value between in [0, 5), with 5 being active
     std::uint8_t    power = 0;
 
-    static auto air() -> pixel;
-    static auto sand() -> pixel;
-    static auto coal() -> pixel;
-    static auto dirt() -> pixel;
-    static auto rock() -> pixel;
-    static auto water() -> pixel;
-    static auto lava() -> pixel;
-    static auto acid() -> pixel;
-    static auto steam() -> pixel;
-    static auto titanium() -> pixel;
-    static auto fuse() -> pixel;
-    static auto ember() -> pixel;
-    static auto oil() -> pixel;
+    static auto air()       -> pixel;
+    static auto sand()      -> pixel;
+    static auto coal()      -> pixel;
+    static auto dirt()      -> pixel;
+    static auto rock()      -> pixel;
+    static auto water()     -> pixel;
+    static auto lava()      -> pixel;
+    static auto acid()      -> pixel;
+    static auto steam()     -> pixel;
+    static auto titanium()  -> pixel;
+    static auto fuse()      -> pixel;
+    static auto ember()     -> pixel;
+    static auto oil()       -> pixel;
     static auto gunpowder() -> pixel;
-    static auto methane() -> pixel;
-    static auto battery() -> pixel;
-    static auto solder() -> pixel;
-    static auto diode_in() -> pixel;
+    static auto methane()   -> pixel;
+    static auto battery()   -> pixel;
+    static auto solder()    -> pixel;
+    static auto diode_in()  -> pixel;
     static auto diode_out() -> pixel;
-    static auto spark() -> pixel;
-    static auto c4() -> pixel;
-    static auto relay() -> pixel;
+    static auto spark()     -> pixel;
+    static auto c4()        -> pixel;
+    static auto relay()     -> pixel;
 };
 
 auto properties(const pixel& px) -> const pixel_properties&;

--- a/src/core/renderer.cpp
+++ b/src/core/renderer.cpp
@@ -140,6 +140,9 @@ auto renderer::update(const level& world) -> void
                         const auto t = static_cast<float>(pixel.power) / props.power_max;
                         colour = sand::lerp(a, b, t);
                     }
+                    else if (pixel.type == pixel_type::none) {
+                        colour = {0.0, 0.0, 0.0, 0.0};
+                    }
                     else {
                         colour = pixel.colour;
                     }
@@ -163,7 +166,11 @@ auto renderer::draw(const camera& camera) const -> void
     d_shader.load_mat4("u_proj_matrix", projection);
     
     d_texture.bind();
+    glEnable(GL_BLEND);
+    glBlendEquation(GL_FUNC_ADD);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, nullptr);
+    glDisable(GL_BLEND);
 }
 
 auto renderer::resize(u32 width, u32 height) -> void

--- a/src/core/window.cpp
+++ b/src/core/window.cpp
@@ -150,8 +150,8 @@ auto window::begin_frame(glm::vec4 colour) -> void
 {
     d_data.events.clear();
     glfwPollEvents();
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
     glClearColor(colour.r, colour.g, colour.b, colour.a);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 }
 
 auto window::end_frame() -> void

--- a/src/core/world.cpp
+++ b/src/core/world.cpp
@@ -495,7 +495,6 @@ level::level(i32 width, i32 height, const std::vector<pixel>& data, pixel_pos sp
     , listener{this}
 {
     pixels.physics().SetContactListener(&listener);
-    player = add_player(entities, pixels.physics(), spawn);
 }
 
 }

--- a/src/editor.m.cpp
+++ b/src/editor.m.cpp
@@ -176,9 +176,6 @@ auto main() -> int
                 ImGui::Text("  pixel power: n/a");
                 ImGui::Text("  is_falling: n/a");
             }
-
-            const auto num_floors = level->entities.get<player_component>(level->player).floors.size();
-            ImGui::Text("Number of Floors: %d", num_floors);
             ImGui::Text("Events this frame: %zu", window.events().size());
             ImGui::Separator();
 
@@ -251,6 +248,8 @@ auto main() -> int
         }
         ImGui::End();
 
+        // The shape renderer is used twice per frame, which is a bit of a hack,
+        // but an easy way to draw a quad behind the level.
         shape_renderer.begin_frame(camera);
         shape_renderer.draw_rect(
             {0, 0},

--- a/src/editor.m.cpp
+++ b/src/editor.m.cpp
@@ -98,7 +98,6 @@ auto main() -> int
             }
 
             input.on_event(event);
-            ecs_on_event(level->entities, event);
 
             if (const auto e = event.get_if<sand::window_resize_event>()) {
                 camera.screen_width = e->width;
@@ -124,8 +123,6 @@ auto main() -> int
             updated = true;
             level->pixels.step();
         }
-
-        ecs_on_update(level->entities, input);
 
         const auto mouse_pos = pixel_at_mouse(input, camera);
         switch (editor.brush_type) {
@@ -196,9 +193,6 @@ auto main() -> int
             ImGui::Checkbox("Show Spawn", &editor.show_spawn);
             ImGui::SliderInt("Spawn X", &level->spawn_point.x, 0, level->pixels.width_in_pixels());
             ImGui::SliderInt("Spawn Y", &level->spawn_point.y, 0, level->pixels.height_in_pixels());
-            if (ImGui::Button("Respawn")) {
-                ecs_entity_respawn(level->entities, level->player);
-            }
             ImGui::Separator();
 
             ImGui::Text("Info");
@@ -257,6 +251,15 @@ auto main() -> int
         }
         ImGui::End();
 
+        shape_renderer.begin_frame(camera);
+        shape_renderer.draw_rect(
+            {0, 0},
+            config::chunk_size * level->pixels.width_in_chunks(),
+            config::chunk_size * level->pixels.height_in_chunks(),
+            {0.1, 0.1, 0.1, 1.0}
+        );
+        shape_renderer.end_frame();
+
         // Render and display the world
         if (updated) {
             world_renderer.update(*level);
@@ -264,9 +267,6 @@ auto main() -> int
         world_renderer.draw(camera);
 
         shape_renderer.begin_frame(camera);
-
-        // TODO: Replace with actual sprite data
-        shape_renderer.draw_circle(ecs_entity_centre(level->entities, level->player), {1.0, 1.0, 0.0, 1.0}, 3);
 
         if (editor.show_physics) {
             level->pixels.physics().SetDebugDraw(&debug_draw);

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -95,6 +95,7 @@ auto scene_level(sand::window& window) -> next_state
     auto debug_renderer  = sand::physics_debug_draw{&shape_renderer};
     auto ui              = sand::ui_engine{};
 
+    level->player = add_player(level->entities, level->pixels.physics(), level->spawn_point);
     const auto player_pos = glm::ivec2{ecs_entity_centre(level->entities, level->player) + glm::vec2{200, 0}};
     add_enemy(level->entities, level->pixels.physics(), pixel_pos::from_ivec2(player_pos));
     
@@ -104,6 +105,9 @@ auto scene_level(sand::window& window) -> next_state
         .screen_height = window.height(),
         .world_to_screen = window.height() / 210.0f
     };
+
+    // This can be done a litle better surely.
+    camera.top_left = ecs_entity_centre(level->entities, level->player) - sand::dimensions(camera) / (2.0f * camera.world_to_screen);
     
     while (window.is_running()) {
         const double dt = timer.on_update();

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -23,13 +23,13 @@ enum class next_state
     exit,
 };
 
+constexpr auto clear_colour = sand::from_hex(0x222f3e);
+
 auto scene_main_menu(sand::window& window) -> next_state
 {
     using namespace sand;
     auto timer = sand::timer{};
     auto ui    = sand::ui_engine{};
-
-    constexpr auto clear_colour = from_hex(0x222f3e);
 
     while (window.is_running()) {
         const double dt = timer.on_update();
@@ -107,7 +107,7 @@ auto scene_level(sand::window& window) -> next_state
     
     while (window.is_running()) {
         const double dt = timer.on_update();
-        window.begin_frame();
+        window.begin_frame(clear_colour);
         input.on_new_frame();
         
         for (const auto event : window.events()) {


### PR DESCRIPTION
* Until now, I was giving air pixel the "background colour" and rendering it like normal. This needs to change so that I can add a background parallax effect.
* Now, the renderer treats air as a special case, and renders it as clear, ignoring the colour in the pixel. `pixel::air()` now colours the pixel back, but transparent. The pixels in the world saves still have the old colour, but there's no need to remove that.
* Removed the player from the editor as well as all entity updating since it isn't needed and should serve only as a level editor.
* Remove the hard-coded player entity from the level constructor. This is just added in the game now. This will be improved when we have a way to save/load whole level states, including entities.
* In the editor, we now render a quad behind the world first to make it clear where the borders are.