### PR TITLE
Grenade Launcher

### DIFF
--- a/src/core/common.hpp
+++ b/src/core/common.hpp
@@ -63,3 +63,13 @@ struct chunk_pos
 };
 
 }
+
+template <>
+struct std::hash<sand::chunk_pos>
+{
+    auto operator()(sand::chunk_pos pos) const noexcept -> std::size_t
+    {
+        static const auto hasher = std::hash<sand::i32>{};
+        return hasher(pos.x) ^ hasher(pos.y);
+    }
+};

--- a/src/core/context.hpp
+++ b/src/core/context.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include "input.hpp"
+#include "camera.hpp"
+
+namespace sand {
+
+class window;
+
+// This just aggregates all of the key non-level pieces of the code
+// needed in the update logic.
+struct context
+{
+    window* window;
+    input   input;
+    camera  camera;
+};
+
+}

--- a/src/core/entity.cpp
+++ b/src/core/entity.cpp
@@ -1,5 +1,6 @@
 #include "entity.hpp"
 #include "world.hpp"
+#include "explosion.hpp"
 
 #include <box2d/b2_body.h>
 
@@ -24,8 +25,9 @@ void contact_listener::begin_contact(b2Fixture* curr, b2Fixture* other)
         && !d_level->entities.has<player_component>(other_entity)
         && !other->IsSensor())
     {
-        std::print("grenade has impacted\n");
         d_level->entities.mark_for_death(curr_entity);
+        const auto pos = ecs_entity_centre(d_level->entities, curr_entity);
+        apply_explosion(d_level->pixels, pixel_pos::from_ivec2(pos), explosion{.min_radius=5, .max_radius=10, .scorch=15});   
     }
     
     if (d_level->entities.has<player_component>(curr_entity) && !other->IsSensor()) {

--- a/src/core/entity.cpp
+++ b/src/core/entity.cpp
@@ -37,7 +37,7 @@ auto update_player(registry& entities, entity e, const input& in) -> void
         if (vel.x < max_vel) desired_vel = b2Min(vel.x + max_vel, max_vel);
     }
 
-    body_comp.body_fixture->SetFriction(desired_vel != 0 ? 0.2f : 0.95f);
+    body_comp.body_fixture->SetFriction((desired_vel != 0) ? 0.1f : 0.3f);
 
     float vel_change = desired_vel - vel.x;
     float impulse = body_comp.body->GetMass() * vel_change;

--- a/src/core/entity.cpp
+++ b/src/core/entity.cpp
@@ -25,6 +25,7 @@ void contact_listener::begin_contact(b2Fixture* curr, b2Fixture* other)
         && !other->IsSensor())
     {
         std::print("grenade has impacted\n");
+        d_level->entities.mark_for_death(curr_entity);
     }
     
     if (d_level->entities.has<player_component>(curr_entity) && !other->IsSensor()) {

--- a/src/core/entity.cpp
+++ b/src/core/entity.cpp
@@ -19,6 +19,13 @@ void contact_listener::begin_contact(b2Fixture* curr, b2Fixture* other)
 {
     const auto curr_entity = static_cast<entity>(curr->GetBody()->GetUserData().pointer);
     const auto other_entity = static_cast<entity>(other->GetBody()->GetUserData().pointer);
+
+    if (d_level->entities.has<grenade_component>(curr_entity) 
+        && !d_level->entities.has<player_component>(other_entity)
+        && !other->IsSensor())
+    {
+        std::print("grenade has impacted\n");
+    }
     
     if (d_level->entities.has<player_component>(curr_entity) && !other->IsSensor()) {
         auto& comp = d_level->entities.get<player_component>(curr_entity);

--- a/src/core/entity.cpp
+++ b/src/core/entity.cpp
@@ -4,98 +4,6 @@
 #include <box2d/b2_body.h>
 
 namespace sand {
-namespace {
-
-static constexpr auto player_id = 1;
-static constexpr auto enemy_id = 2;
-
-static_assert(sizeof(std::uintptr_t) == sizeof(entity));
-
-auto update_player(registry& entities, entity e, const input& in) -> void
-{
-    auto [body_comp, player_comp] = entities.get_all<body_component, player_component>(e);
-    
-    const bool on_ground = !player_comp.floors.empty();
-    const bool can_move_left = player_comp.num_left_contacts == 0;
-    const bool can_move_right = player_comp.num_right_contacts == 0;
-
-    const auto vel = body_comp.body->GetLinearVelocity();
-    
-    auto direction = 0;
-    if (can_move_left && in.is_down(keyboard::A)) {
-        direction -= 1;
-    }
-    if (can_move_right && in.is_down(keyboard::D)) {
-        direction += 1;
-    }
-    
-    const auto max_vel = 5.0f;
-    auto desired_vel = 0.0f;
-    if (direction == -1) { // left
-        if (vel.x > -max_vel) desired_vel = b2Max(vel.x - max_vel, -max_vel);
-    } else if (direction == 1) { // right
-        if (vel.x < max_vel) desired_vel = b2Min(vel.x + max_vel, max_vel);
-    }
-
-    body_comp.body_fixture->SetFriction((desired_vel != 0) ? 0.1f : 0.3f);
-
-    float vel_change = desired_vel - vel.x;
-    float impulse = body_comp.body->GetMass() * vel_change;
-    body_comp.body->ApplyLinearImpulseToCenter(b2Vec2(impulse, 0), true);
-
-    if (on_ground) {
-        player_comp.double_jump = true;
-        player_comp.ground_pound = true;
-    }
-}
-
-auto update_enemy(registry& entities, entity e) -> void
-{
-    if (entities.has<enemy_component>(e)) {
-        auto [body_comp, enemy_comp] = entities.get_all<body_component, enemy_component>(e);
-        for (const auto curr : enemy_comp.nearby_entities) {
-            if (entities.has<player_component>(curr)) {
-                auto& curr_body_comp = entities.get<body_component>(curr);
-                const auto pos = physics_to_pixel(curr_body_comp.body->GetPosition());
-                const auto self_pos = ecs_entity_centre(entities, e);
-                const auto dir = glm::normalize(pos - self_pos);
-                body_comp.body->ApplyLinearImpulseToCenter(pixel_to_physics(0.25f * dir), true);
-            }
-        }
-    }
-}
-
-auto player_handle_event(registry& entities, entity e, const event& ev) -> void
-{
-    auto [body_comp, player_comp] = entities.get_all<body_component, player_component>(e);
-
-    const bool on_ground = !player_comp.floors.empty();
-    if (const auto inner = ev.get_if<keyboard_pressed_event>()) {
-        if (inner->key == keyboard::space) {
-            if (on_ground || player_comp.double_jump) {
-                if (!on_ground) {
-                    player_comp.double_jump = false;
-                }
-                const auto impulse = body_comp.body->GetMass() * 7;
-                body_comp.body->ApplyLinearImpulseToCenter(b2Vec2(0, -impulse), true);
-            }
-        }
-        else if (inner->key == keyboard::S) {
-            if (player_comp.ground_pound) {
-                player_comp.ground_pound = false;
-                const auto impulse = body_comp.body->GetMass() * 7;
-                body_comp.body->ApplyLinearImpulseToCenter(b2Vec2(0, impulse), true);
-            }
-        }
-    }
-    else if (const auto inner = ev.get_if<mouse_pressed_event>()) {
-        if (inner->button == mouse::left) {
-            std::print("spawning bullet\n");
-        }
-    }
-}
-
-}
 
 void contact_listener::PreSolve(b2Contact* contact, const b2Manifold*) 
 {
@@ -298,23 +206,6 @@ auto add_enemy(registry& entities, b2World& world, pixel_pos position) -> entity
     }
 
     return e;
-}
-
-auto ecs_on_update(registry& entities, const input& in) -> void
-{
-    for (auto e : entities.view<player_component>()) {
-        update_player(entities, e, in);
-    }
-    for (auto e : entities.view<enemy_component>()) {
-        update_enemy(entities, e);
-    }
-}
-
-auto ecs_on_event(registry& entities, const event& ev) -> void
-{
-    for (auto e : entities.view<body_component, player_component>()) {
-        player_handle_event(entities, e, ev);
-    }
 }
 
 auto ecs_entity_respawn(const registry& entities, entity e) -> void

--- a/src/core/entity.hpp
+++ b/src/core/entity.hpp
@@ -71,8 +71,6 @@ using registry = apx::registry<
 auto add_player(registry& entities, b2World& world, pixel_pos position) -> entity;
 auto add_enemy(registry& entities, b2World& world, pixel_pos position) -> entity;
 
-auto ecs_on_update(registry& entities, const input& in) -> void;
-auto ecs_on_event(registry& entities, const event& ev) -> void;
 auto ecs_entity_respawn(const registry& entities, entity e) -> void;
 auto ecs_entity_centre(const registry& entities, entity e) -> glm::vec2;
 

--- a/src/core/entity.hpp
+++ b/src/core/entity.hpp
@@ -60,13 +60,16 @@ struct life_component
     i32       health      = 100;
 };
 
+struct grenade_component
+{};
+
 using registry = apx::registry<
     body_component,
     player_component,
     enemy_component,
-    life_component
+    life_component,
+    grenade_component
 >;
-
 
 auto add_player(registry& entities, b2World& world, pixel_pos position) -> entity;
 auto add_enemy(registry& entities, b2World& world, pixel_pos position) -> entity;

--- a/src/core/explosion.cpp
+++ b/src/core/explosion.cpp
@@ -14,7 +14,7 @@ auto nearest_pixel(glm::vec2 pos) -> pixel_pos
     return {static_cast<int>(pos.x), static_cast<int>(pos.y)};
 }
 
-auto explosion_ray(world& w, glm::vec2 start, glm::vec2 end, const explosion& info) -> void
+auto explosion_ray(pixel_world& w, glm::vec2 start, glm::vec2 end, const explosion& info) -> void
 {
     // Calculate a step length small enough to hit every pixel on the path.
     const auto line = end - start;
@@ -49,7 +49,7 @@ auto explosion_ray(world& w, glm::vec2 start, glm::vec2 end, const explosion& in
 
 }
 
-auto apply_explosion(world& w, pixel_pos pos, const explosion& info) -> void
+auto apply_explosion(pixel_world& w, pixel_pos pos, const explosion& info) -> void
 {
     const auto p = glm::vec2{pos.x, pos.y};
     const auto a = info.max_radius + 3 * info.scorch;

--- a/src/core/explosion.hpp
+++ b/src/core/explosion.hpp
@@ -17,6 +17,6 @@ struct explosion
     float scorch;
 };
 
-auto apply_explosion(world& w, pixel_pos pos, const explosion& info) -> void;
+auto apply_explosion(pixel_world& w, pixel_pos pos, const explosion& info) -> void;
 
 }

--- a/src/core/update_rigid_bodies.cpp
+++ b/src/core/update_rigid_bodies.cpp
@@ -15,7 +15,7 @@ using chunk_static_pixels = std::bitset<sand::config::chunk_size * sand::config:
 
 auto is_static_pixel(
     pixel_pos top_left,
-    const world& w,
+    const pixel_world& w,
     pixel_pos pos) -> bool
 {
     if (!(top_left.x <= pos.x && pos.x < top_left.x + sand::config::chunk_size) || !(top_left.y <= pos.y && pos.y < top_left.y + sand::config::chunk_size)) return false;
@@ -30,7 +30,7 @@ auto is_static_pixel(
 
 auto is_static_boundary(
     pixel_pos top_left,
-    const world& w,
+    const pixel_world& w,
     pixel_pos A, glm::ivec2 offset) -> bool
 {
     assert(glm::abs(offset.x) + glm::abs(offset.y) == 1);
@@ -41,7 +41,7 @@ auto is_static_boundary(
 
 auto is_along_boundary(
     pixel_pos top_left,
-    const world& w,
+    const pixel_world& w,
     pixel_pos curr, pixel_pos next) -> bool
 {
     const auto offset = next - curr;
@@ -55,7 +55,7 @@ auto is_along_boundary(
 
 auto is_boundary_cross(
     pixel_pos top_left,
-    const world& w,
+    const pixel_world& w,
     pixel_pos curr) -> bool
 {
     const auto tl = is_static_pixel(top_left, w, curr + left + up);
@@ -67,7 +67,7 @@ auto is_boundary_cross(
 
 auto is_valid_step(
     pixel_pos top_left,
-    const world& w,
+    const pixel_world& w,
     pixel_pos prev,
     pixel_pos curr,
     pixel_pos next) -> bool
@@ -93,7 +93,7 @@ auto is_valid_step(
 
 auto get_boundary(
     pixel_pos top_left,
-    const world& w,
+    const pixel_world& w,
     pixel_pos start) -> std::vector<pixel_pos>
 {
     auto ret = std::vector<pixel_pos>{};
@@ -179,7 +179,7 @@ auto ramer_douglas_puecker(std::span<const pixel_pos> points, float epsilon, std
 
 auto calc_boundary(
     pixel_pos top_left,
-    const world& w,
+    const pixel_world& w,
     pixel_pos start,
     float epsilon) -> std::vector<pixel_pos>
 {
@@ -243,7 +243,7 @@ auto get_start_pixel_offset(const chunk_static_pixels& pixels) -> glm::ivec2
 
 auto create_chunk_triangles(level& l, pixel_pos top_left) -> b2Body*
 {
-    auto body = new_body(l.physics);
+    auto body = new_body(l.physics.world);
     
     auto chunk_pixels = chunk_static_pixels{};
     

--- a/src/core/update_rigid_bodies.cpp
+++ b/src/core/update_rigid_bodies.cpp
@@ -192,14 +192,17 @@ auto calc_boundary(
     return simplified;
 }
 
-auto new_body(b2World& world) -> b2Body*
+auto new_body(level& l) -> b2Body*
 {
+    auto e = l.entities.create();
+    auto& comp = l.entities.emplace<body_component>(e);
+
     b2BodyDef bodyDef;
     bodyDef.type = b2_staticBody;
     bodyDef.position.Set(0.0f, 0.0f);
-    auto body = world.CreateBody(&bodyDef);
-    body->GetUserData().pointer = static_cast<std::uintptr_t>(apx::null);
-    return body;
+    comp.body = l.physics.world.CreateBody(&bodyDef);
+    comp.body->GetUserData().pointer = static_cast<std::uintptr_t>(apx::null);
+    return comp.body;
 }
 
 auto flood_remove(chunk_static_pixels& pixels, glm::ivec2 offset) -> void
@@ -243,7 +246,7 @@ auto get_start_pixel_offset(const chunk_static_pixels& pixels) -> glm::ivec2
 
 auto create_chunk_triangles(level& l, pixel_pos top_left) -> b2Body*
 {
-    auto body = new_body(l.physics.world);
+    auto body = new_body(l);
     
     auto chunk_pixels = chunk_static_pixels{};
     

--- a/src/core/update_rigid_bodies.hpp
+++ b/src/core/update_rigid_bodies.hpp
@@ -3,10 +3,11 @@
 
 #include "common.hpp"
 
+class b2Body;
+
 namespace sand {
 
-class world;
-class chunk;
-auto create_chunk_triangles(world& w, chunk& c, pixel_pos top_left) -> void;
+class level;
+auto create_chunk_triangles(level& l, pixel_pos top_left) -> b2Body*;
 
 }

--- a/src/core/world.cpp
+++ b/src/core/world.cpp
@@ -583,18 +583,18 @@ level::level(i32 width, i32 height, const std::vector<pixel>& data, pixel_pos sp
     pixels.physics().SetContactListener(&listener);
 }
 
-auto level_on_update(level& l, const input& in) -> void
+auto level_on_update(level& l, const context& ctx) -> void
 {
     l.pixels.step();
     for (auto e : l.entities.view<player_component>()) {
-        update_player(l.entities, e, in);
+        update_player(l.entities, e, ctx.input);
     }
     for (auto e : l.entities.view<enemy_component>()) {
         update_enemy(l.entities, e);
     }
 }
 
-auto level_on_event(level& l, const event& ev) -> void
+auto level_on_event(level& l, const context& ctx, const event& ev) -> void
 {
     for (auto e : l.entities.view<body_component, player_component>()) {
         player_handle_event(l.entities, e, ev);

--- a/src/core/world.cpp
+++ b/src/core/world.cpp
@@ -500,7 +500,9 @@ auto pixel_world::at(pixel_pos pos) -> pixel&
 auto pixel_world::at(chunk_pos pos) -> chunk&
 {
     assert(is_valid_chunk(pos));
-    return d_chunks[pos.x + width_in_chunks() * pos.y];
+    const auto index = pos.x + width_in_chunks() * pos.y;
+    assert(index < d_chunks.size());
+    return d_chunks[index];
 }
 
 auto pixel_world::is_valid_pixel(pixel_pos pos) const -> bool
@@ -615,7 +617,6 @@ auto level_on_update(level& l, const context& ctx) -> void
 
     const auto width_chunks = l.pixels.width_in_chunks();
     const auto height_chunks = l.pixels.height_in_chunks();
-    std::print("width in chunks: {}, height in chunks: {}\n", width_chunks, height_chunks);
     for (i32 x = 0; x != width_chunks; ++x) {
         for (i32 y = 0; y != height_chunks; ++y) {
             const auto pos = chunk_pos{x, y};
@@ -644,7 +645,9 @@ auto level_on_update(level& l, const context& ctx) -> void
     for (auto e : l.entities.marked_entities()) {
         if (l.entities.has<body_component>(e)) {
             const auto& comp = l.entities.get<body_component>(e);
-            l.physics.world.DestroyBody(comp.body);
+            if (comp.body) {
+                l.physics.world.DestroyBody(comp.body);
+            }
         }
     }
     l.entities.destroy_marked();

--- a/src/core/world.cpp
+++ b/src/core/world.cpp
@@ -418,8 +418,6 @@ auto player_handle_event(level& l, const context& ctx, entity e, const event& ev
                 fixtureDef.density = 1.0f;
                 body_comp.body_fixture = body_comp.body->CreateFixture(&fixtureDef);
             }
-
-            std::print("spawning bullet\n");
         }
     }
 }

--- a/src/core/world.cpp
+++ b/src/core/world.cpp
@@ -621,14 +621,13 @@ auto level_on_update(level& l, const context& ctx) -> void
             const auto pos = chunk_pos{x, y};
             const auto& chunk = l.pixels[pos];
             if (!chunk.should_step) continue;
-            const auto top_left = config::chunk_size * glm::ivec2{x, y};
-            const auto tl = pixel_pos{top_left.x, top_left.y};
+            const auto top_left = get_chunk_top_left(pos);
 
             auto& map = l.physics.chunk_bodies;
             if (auto it = map.find(pos); it != map.end()) {
                 l.physics.world.DestroyBody(it->second);
             }
-            l.physics.chunk_bodies[pos] = create_chunk_triangles(l, tl);
+            l.physics.chunk_bodies[pos] = create_chunk_triangles(l, top_left);
             
         }
     }

--- a/src/core/world.cpp
+++ b/src/core/world.cpp
@@ -388,6 +388,7 @@ auto player_handle_event(level& l, const context& ctx, entity e, const event& ev
             
             auto grenade = l.entities.create();
             auto& body_comp = l.entities.emplace<body_component>(grenade);
+            l.entities.emplace<grenade_component>(grenade);
             
             // Create player body
             b2BodyDef body_def;
@@ -399,7 +400,7 @@ auto player_handle_event(level& l, const context& ctx, entity e, const event& ev
             const auto pos = pixel_to_physics(spawn_pot);
             body_def.position.Set(pos.x, pos.y);
             body_comp.body = l.pixels.physics().CreateBody(&body_def);
-            body_comp.body->GetUserData().pointer = static_cast<std::uintptr_t>(e);
+            body_comp.body->GetUserData().pointer = static_cast<std::uintptr_t>(grenade);
             b2MassData md;
             md.mass = 10;
             body_comp.body->SetMassData(&md);

--- a/src/core/world.cpp
+++ b/src/core/world.cpp
@@ -615,20 +615,19 @@ auto level_on_update(level& l, const context& ctx) -> void
 
     const auto width_chunks = l.pixels.width_in_chunks();
     const auto height_chunks = l.pixels.height_in_chunks();
-
+    std::print("width in chunks: {}, height in chunks: {}\n", width_chunks, height_chunks);
     for (i32 x = 0; x != width_chunks; ++x) {
         for (i32 y = 0; y != height_chunks; ++y) {
             const auto pos = chunk_pos{x, y};
-            const auto& chunk = l.pixels[pos];
-            if (!chunk.should_step) continue;
-            const auto top_left = get_chunk_top_left(pos);
-
+            if (!l.pixels[pos].should_step) continue;
+            
             auto& map = l.physics.chunk_bodies;
             if (auto it = map.find(pos); it != map.end()) {
                 l.physics.world.DestroyBody(it->second);
+                map.erase(it);
             }
-            l.physics.chunk_bodies[pos] = create_chunk_triangles(l, top_left);
-            
+            const auto top_left = get_chunk_top_left(pos);
+            map[pos] = create_chunk_triangles(l, top_left); 
         }
     }
 

--- a/src/core/world.cpp
+++ b/src/core/world.cpp
@@ -357,6 +357,92 @@ auto get_chunk_from_pixel(pixel_pos pos) -> chunk_pos
     return {pos.x / config::chunk_size, pos.y / config::chunk_size};
 }
 
+auto player_handle_event(registry& entities, entity e, const event& ev) -> void
+{
+    auto [body_comp, player_comp] = entities.get_all<body_component, player_component>(e);
+
+    const bool on_ground = !player_comp.floors.empty();
+    if (const auto inner = ev.get_if<keyboard_pressed_event>()) {
+        if (inner->key == keyboard::space) {
+            if (on_ground || player_comp.double_jump) {
+                if (!on_ground) {
+                    player_comp.double_jump = false;
+                }
+                const auto impulse = body_comp.body->GetMass() * 7;
+                body_comp.body->ApplyLinearImpulseToCenter(b2Vec2(0, -impulse), true);
+            }
+        }
+        else if (inner->key == keyboard::S) {
+            if (player_comp.ground_pound) {
+                player_comp.ground_pound = false;
+                const auto impulse = body_comp.body->GetMass() * 7;
+                body_comp.body->ApplyLinearImpulseToCenter(b2Vec2(0, impulse), true);
+            }
+        }
+    }
+    else if (const auto inner = ev.get_if<mouse_pressed_event>()) {
+        if (inner->button == mouse::left) {
+            std::print("spawning bullet\n");
+        }
+    }
+}
+
+static_assert(sizeof(std::uintptr_t) == sizeof(entity));
+
+auto update_player(registry& entities, entity e, const input& in) -> void
+{
+    auto [body_comp, player_comp] = entities.get_all<body_component, player_component>(e);
+    
+    const bool on_ground = !player_comp.floors.empty();
+    const bool can_move_left = player_comp.num_left_contacts == 0;
+    const bool can_move_right = player_comp.num_right_contacts == 0;
+
+    const auto vel = body_comp.body->GetLinearVelocity();
+    
+    auto direction = 0;
+    if (can_move_left && in.is_down(keyboard::A)) {
+        direction -= 1;
+    }
+    if (can_move_right && in.is_down(keyboard::D)) {
+        direction += 1;
+    }
+    
+    const auto max_vel = 5.0f;
+    auto desired_vel = 0.0f;
+    if (direction == -1) { // left
+        if (vel.x > -max_vel) desired_vel = b2Max(vel.x - max_vel, -max_vel);
+    } else if (direction == 1) { // right
+        if (vel.x < max_vel) desired_vel = b2Min(vel.x + max_vel, max_vel);
+    }
+
+    body_comp.body_fixture->SetFriction((desired_vel != 0) ? 0.1f : 0.3f);
+
+    float vel_change = desired_vel - vel.x;
+    float impulse = body_comp.body->GetMass() * vel_change;
+    body_comp.body->ApplyLinearImpulseToCenter(b2Vec2(impulse, 0), true);
+
+    if (on_ground) {
+        player_comp.double_jump = true;
+        player_comp.ground_pound = true;
+    }
+}
+
+auto update_enemy(registry& entities, entity e) -> void
+{
+    if (entities.has<enemy_component>(e)) {
+        auto [body_comp, enemy_comp] = entities.get_all<body_component, enemy_component>(e);
+        for (const auto curr : enemy_comp.nearby_entities) {
+            if (entities.has<player_component>(curr)) {
+                auto& curr_body_comp = entities.get<body_component>(curr);
+                const auto pos = physics_to_pixel(curr_body_comp.body->GetPosition());
+                const auto self_pos = ecs_entity_centre(entities, e);
+                const auto dir = glm::normalize(pos - self_pos);
+                body_comp.body->ApplyLinearImpulseToCenter(pixel_to_physics(0.25f * dir), true);
+            }
+        }
+    }
+}
+
 }
 
 auto get_chunk_top_left(chunk_pos pos) -> pixel_pos
@@ -500,12 +586,19 @@ level::level(i32 width, i32 height, const std::vector<pixel>& data, pixel_pos sp
 auto level_on_update(level& l, const input& in) -> void
 {
     l.pixels.step();
-    ecs_on_update(l.entities, in);
+    for (auto e : l.entities.view<player_component>()) {
+        update_player(l.entities, e, in);
+    }
+    for (auto e : l.entities.view<enemy_component>()) {
+        update_enemy(l.entities, e);
+    }
 }
 
-auto level_on_event(level& l, const event& e) -> void
+auto level_on_event(level& l, const event& ev) -> void
 {
-    ecs_on_event(l.entities, e);
+    for (auto e : l.entities.view<body_component, player_component>()) {
+        player_handle_event(l.entities, e, ev);
+    }
 }
 
 

--- a/src/core/world.cpp
+++ b/src/core/world.cpp
@@ -497,4 +497,16 @@ level::level(i32 width, i32 height, const std::vector<pixel>& data, pixel_pos sp
     pixels.physics().SetContactListener(&listener);
 }
 
+auto level_on_update(level& l, const input& in) -> void
+{
+    l.pixels.step();
+    ecs_on_update(l.entities, in);
+}
+
+auto level_on_event(level& l, const event& e) -> void
+{
+    ecs_on_event(l.entities, e);
+}
+
+
 }

--- a/src/core/world.hpp
+++ b/src/core/world.hpp
@@ -23,10 +23,9 @@ struct chunk
 {
     bool    should_step      = true;
     bool    should_step_next = true;
-    b2Body* triangles        = nullptr;
 };
 
-class world
+class pixel_world
 {
     std::vector<pixel> d_pixels;
     std::vector<chunk> d_chunks;
@@ -38,8 +37,8 @@ class world
 
     auto wake_chunk(chunk_pos pos) -> void;
     
-    public:
-    world(i32 width, i32 height, const std::vector<pixel>& pixels)
+public:
+    pixel_world(i32 width, i32 height, const std::vector<pixel>& pixels)
         : d_pixels{pixels}
         , d_width{width}
         , d_height{height}
@@ -51,10 +50,10 @@ class world
         const auto height_chunks = height / config::chunk_size;
         d_chunks.resize(width_chunks * height_chunks);
     }
-    world(const world&) = delete;
-    world(world&&) = delete;
-    world& operator=(const world&) = delete;
-    world& operator=(world&&) = delete;
+    pixel_world(const pixel_world&) = delete;
+    pixel_world(pixel_world&&) = delete;
+    pixel_world& operator=(const pixel_world&) = delete;
+    pixel_world& operator=(pixel_world&&) = delete;
     
     auto step() -> void;
 
@@ -67,7 +66,6 @@ class world
     auto swap(pixel_pos a, pixel_pos b) -> void;
     auto operator[](pixel_pos pos) const -> const pixel&;
     auto operator[](chunk_pos pos) const -> const chunk&;
-    auto set_chunk_body(chunk_pos pos, b2Body* body) -> void;
     
     auto visit_no_wake(pixel_pos pos, auto&& updater) -> void
     {
@@ -90,10 +88,18 @@ class world
     auto pixels() const -> const std::vector<pixel>& { return d_pixels; }
 };
 
+struct physics_world
+{
+    b2World world;
+    std::unordered_map<chunk_pos, b2Body*> chunk_bodies;
+
+    physics_world(glm::vec2 gravity);
+};
+
 struct level
 {
-    world            pixels;
-    b2World          physics;
+    pixel_world      pixels;
+    physics_world    physics;
     pixel_pos        spawn_point;
     registry         entities;
     entity           player;

--- a/src/core/world.hpp
+++ b/src/core/world.hpp
@@ -100,8 +100,9 @@ struct level
 {
     pixel_world      pixels;
     physics_world    physics;
-    pixel_pos        spawn_point;
     registry         entities;
+    
+    pixel_pos        spawn_point;
     entity           player;
     contact_listener listener;
 

--- a/src/core/world.hpp
+++ b/src/core/world.hpp
@@ -4,6 +4,7 @@
 #include "serialise.hpp"
 #include "world_save.hpp"
 #include "entity.hpp"
+#include "context.hpp"
 
 #include <cstdint>
 #include <unordered_set>
@@ -103,7 +104,7 @@ struct level
     level(i32 width, i32 height, const std::vector<pixel>& pixels, pixel_pos spawn);
 };
 
-auto level_on_update(level& l, const input& in) -> void;
-auto level_on_event(level& l, const event& e) -> void;
+auto level_on_update(level& l, const context& ctx) -> void;
+auto level_on_event(level& l, const context& ctx, const event& e) -> void;
 
 }

--- a/src/core/world.hpp
+++ b/src/core/world.hpp
@@ -103,4 +103,7 @@ struct level
     level(i32 width, i32 height, const std::vector<pixel>& pixels, pixel_pos spawn);
 };
 
+auto level_on_update(level& l, const input& in) -> void;
+auto level_on_event(level& l, const event& e) -> void;
+
 }

--- a/src/core/world.hpp
+++ b/src/core/world.hpp
@@ -28,7 +28,6 @@ struct chunk
 
 class world
 {
-    b2World            d_physics;
     std::vector<pixel> d_pixels;
     std::vector<chunk> d_chunks;
     i32                d_width;
@@ -41,8 +40,7 @@ class world
     
     public:
     world(i32 width, i32 height, const std::vector<pixel>& pixels)
-        : d_physics{{config::gravity.x, config::gravity.y}}
-        , d_pixels{pixels}
+        : d_pixels{pixels}
         , d_width{width}
         , d_height{height}
     {
@@ -58,8 +56,6 @@ class world
     world& operator=(const world&) = delete;
     world& operator=(world&&) = delete;
     
-    auto physics() -> b2World& { return d_physics; }
-    
     auto step() -> void;
 
     auto wake_chunk_with_pixel(pixel_pos pixel) -> void;
@@ -71,6 +67,7 @@ class world
     auto swap(pixel_pos a, pixel_pos b) -> void;
     auto operator[](pixel_pos pos) const -> const pixel&;
     auto operator[](chunk_pos pos) const -> const chunk&;
+    auto set_chunk_body(chunk_pos pos, b2Body* body) -> void;
     
     auto visit_no_wake(pixel_pos pos, auto&& updater) -> void
     {
@@ -96,6 +93,7 @@ class world
 struct level
 {
     world            pixels;
+    b2World          physics;
     pixel_pos        spawn_point;
     registry         entities;
     entity           player;

--- a/src/core/world.hpp
+++ b/src/core/world.hpp
@@ -50,10 +50,6 @@ public:
         const auto height_chunks = height / config::chunk_size;
         d_chunks.resize(width_chunks * height_chunks);
     }
-    pixel_world(const pixel_world&) = delete;
-    pixel_world(pixel_world&&) = delete;
-    pixel_world& operator=(const pixel_world&) = delete;
-    pixel_world& operator=(pixel_world&&) = delete;
     
     auto step() -> void;
 
@@ -101,7 +97,7 @@ struct level
     pixel_world      pixels;
     physics_world    physics;
     registry         entities;
-    
+
     pixel_pos        spawn_point;
     entity           player;
     contact_listener listener;

--- a/src/editor.m.cpp
+++ b/src/editor.m.cpp
@@ -268,8 +268,8 @@ auto main() -> int
         shape_renderer.begin_frame(camera);
 
         if (editor.show_physics) {
-            level->pixels.physics().SetDebugDraw(&debug_draw);
-            level->pixels.physics().DebugDraw();
+            level->physics.SetDebugDraw(&debug_draw);
+            level->physics.DebugDraw();
         }
 
         if (editor.show_spawn) {

--- a/src/editor.m.cpp
+++ b/src/editor.m.cpp
@@ -29,7 +29,7 @@
 #include <cmath>
 #include <span>
 
-auto num_awake_chunks(const sand::world& w) -> sand::u64
+auto num_awake_chunks(const sand::pixel_world& w) -> sand::u64
 {
     auto count = 0;
     for (sand::i32 x = 0; x != w.width_in_chunks(); ++x) {
@@ -42,7 +42,7 @@ auto num_awake_chunks(const sand::world& w) -> sand::u64
     return count;
 }
 
-auto clear_world(sand::world& w) -> void
+auto clear_world(sand::pixel_world& w) -> void
 {
     w.wake_all();
     for (sand::i32 x = 0; x != w.width_in_pixels(); ++x) {
@@ -268,8 +268,8 @@ auto main() -> int
         shape_renderer.begin_frame(camera);
 
         if (editor.show_physics) {
-            level->physics.SetDebugDraw(&debug_draw);
-            level->physics.DebugDraw();
+            level->physics.world.SetDebugDraw(&debug_draw);
+            level->physics.world.DebugDraw();
         }
 
         if (editor.show_spawn) {

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -94,9 +94,9 @@ auto scene_level(sand::window& window) -> next_state
     auto debug_renderer  = sand::physics_debug_draw{&shape_renderer};
     auto ui              = sand::ui_engine{};
     
-    level->player = add_player(level->entities, level->pixels.physics(), level->spawn_point);
+    level->player = add_player(level->entities, level->physics, level->spawn_point);
     const auto player_pos = glm::ivec2{ecs_entity_centre(level->entities, level->player) + glm::vec2{200, 0}};
-    add_enemy(level->entities, level->pixels.physics(), pixel_pos::from_ivec2(player_pos));
+    add_enemy(level->entities, level->physics, pixel_pos::from_ivec2(player_pos));
     
     auto ctx = context{
         .window=&window,
@@ -167,8 +167,8 @@ auto scene_level(sand::window& window) -> next_state
         const auto centre = ecs_entity_centre(level->entities, level->player);
         const auto direction = glm::normalize(mouse_pos_world_space(ctx.input, ctx.camera) - centre);
         shape_renderer.draw_line(centre, centre + 10.0f * direction, {1, 1, 1, 1}, 2);
-        level->pixels.physics().SetDebugDraw(&debug_renderer);
-        level->pixels.physics().DebugDraw();
+        level->physics.SetDebugDraw(&debug_renderer);
+        level->physics.DebugDraw();
         shape_renderer.end_frame();
         
         std::array<char, 8> buf = {};

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -127,7 +127,7 @@ auto scene_level(sand::window& window) -> next_state
             }
 
             input.on_event(event);
-            ecs_on_event(level->entities, event);
+            level_on_event(*level, event);
         }
         
         accumulator += dt;
@@ -135,8 +135,7 @@ auto scene_level(sand::window& window) -> next_state
         while (accumulator > sand::config::time_step) {
             accumulator -= sand::config::time_step;
             updated = true;
-            ecs_on_update(level->entities, input);
-            level->pixels.step();
+            level_on_update(*level, input);
         }
         
         const auto desired_top_left = ecs_entity_centre(level->entities, level->player) - sand::dimensions(camera) / (2.0f * camera.world_to_screen);

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -94,9 +94,9 @@ auto scene_level(sand::window& window) -> next_state
     auto debug_renderer  = sand::physics_debug_draw{&shape_renderer};
     auto ui              = sand::ui_engine{};
     
-    level->player = add_player(level->entities, level->physics, level->spawn_point);
+    level->player = add_player(level->entities, level->physics.world, level->spawn_point);
     const auto player_pos = glm::ivec2{ecs_entity_centre(level->entities, level->player) + glm::vec2{200, 0}};
-    add_enemy(level->entities, level->physics, pixel_pos::from_ivec2(player_pos));
+    add_enemy(level->entities, level->physics.world, pixel_pos::from_ivec2(player_pos));
     
     auto ctx = context{
         .window=&window,
@@ -167,8 +167,8 @@ auto scene_level(sand::window& window) -> next_state
         const auto centre = ecs_entity_centre(level->entities, level->player);
         const auto direction = glm::normalize(mouse_pos_world_space(ctx.input, ctx.camera) - centre);
         shape_renderer.draw_line(centre, centre + 10.0f * direction, {1, 1, 1, 1}, 2);
-        level->physics.SetDebugDraw(&debug_renderer);
-        level->physics.DebugDraw();
+        level->physics.world.SetDebugDraw(&debug_renderer);
+        level->physics.world.DebugDraw();
         shape_renderer.end_frame();
         
         std::array<char, 8> buf = {};


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/351183a7-38b7-4bea-b8ae-336f516e8dd5)
* Made it possible for the player to shoot a grenade, which explodes on contact with a rigid body, affecting the pixel world with the previously implemented explosion logic.
* This does cause spontaneous freezing, so it's a bad and buggy at the moment, but that will be fixed.
* Fully separated the pixel world and the physics world. The physics world is now stored in the `level` struct, and that stores the chunk's rigid bodies in a map, which updates after the pixel world steps. Now when updating the pixel world, it doesn't need to consider the physics world at all. This does require a bit more care to keep things in sync, but overall I think it's the cleaner design.
* All rigid bodies have a corresponding entity with a `body_component`.
* Add a new feature to apecs; the ability to mark entities for death. In general it's not possible to delete entities during the update loop as it invalidates the overall loops. Instead, we mark them for the death, then at the end of the update function, we can bulk delete all dead entities. It might turn out this is a bad idea; perhaps the better way is to do it with a tag component, but this is fine for now.