### PR TITLE
Fix Entity Leak in Chunk Rigid Bodies

### DIFF
--- a/src/core/update_rigid_bodies.cpp
+++ b/src/core/update_rigid_bodies.cpp
@@ -241,7 +241,7 @@ auto get_start_pixel_offset(const chunk_static_pixels& pixels) -> glm::ivec2
     std::unreachable();
 }
 
-auto create_chunk_triangles(level& l, pixel_pos top_left) -> b2Body*
+auto create_chunk_rigid_bodies(level& l, pixel_pos top_left) -> b2Body*
 {
     auto body = new_body(l);
     

--- a/src/core/update_rigid_bodies.cpp
+++ b/src/core/update_rigid_bodies.cpp
@@ -194,15 +194,12 @@ auto calc_boundary(
 
 auto new_body(level& l) -> b2Body*
 {
-    auto e = l.entities.create();
-    auto& comp = l.entities.emplace<body_component>(e);
-
-    b2BodyDef bodyDef;
-    bodyDef.type = b2_staticBody;
-    bodyDef.position.Set(0.0f, 0.0f);
-    comp.body = l.physics.world.CreateBody(&bodyDef);
-    comp.body->GetUserData().pointer = static_cast<std::uintptr_t>(apx::null);
-    return comp.body;
+    b2BodyDef def;
+    def.type = b2_staticBody;
+    def.position.Set(0.0f, 0.0f);
+    auto body = l.physics.world.CreateBody(&def);
+    body->GetUserData().pointer = static_cast<std::uintptr_t>(apx::null);
+    return body;
 }
 
 auto flood_remove(chunk_static_pixels& pixels, glm::ivec2 offset) -> void

--- a/src/core/update_rigid_bodies.hpp
+++ b/src/core/update_rigid_bodies.hpp
@@ -8,6 +8,6 @@ class b2Body;
 namespace sand {
 
 class level;
-auto create_chunk_triangles(level& l, pixel_pos top_left) -> b2Body*;
+auto create_chunk_rigid_bodies(level& l, pixel_pos top_left) -> b2Body*;
 
 }

--- a/src/core/world.cpp
+++ b/src/core/world.cpp
@@ -628,7 +628,7 @@ auto level_on_update(level& l, const context& ctx) -> void
                 map.erase(it);
             }
             const auto top_left = get_chunk_top_left(pos);
-            map[pos] = create_chunk_triangles(l, top_left); 
+            map[pos] = create_chunk_rigid_bodies(l, top_left); 
         }
     }
 


### PR DESCRIPTION
* In the last PR, I updated the rigid bodies for the chunks to also have an entity assigned, but I didn't really do this properly.
* This resulted in a new entity being created every time the chunk updated, without the old one being cleaned up.
* There was no need for this, and I didn't even make use of the entity (by setting it as the user data for the body), so I've just removed it.
* If we need entities for the chunks, they can always be added later.