### PR TITLE
Upgrade to Box2D 3.1

### DIFF
--- a/src/core/apecs.hpp
+++ b/src/core/apecs.hpp
@@ -217,9 +217,9 @@ public:
 private:
     using tuple_type = std::tuple<apx::sparse_set<Comps>...>;
 
-    apx::sparse_set<apx::entity> d_entities;
-    std::deque<apx::entity>      d_pool;
-    std::vector<apx::entity>     d_marked_for_death;
+    apx::sparse_set<apx::entity>    d_entities;
+    std::deque<apx::entity>         d_pool;
+    std::unordered_set<apx::entity> d_marked_for_death;
 
     tuple_type d_components;
 
@@ -280,7 +280,7 @@ public:
     // end of the frame
     void mark_for_death(const apx::entity entity)
     {
-        d_marked_for_death.push_back(entity);
+        d_marked_for_death.insert(entity);
     }
 
     void destroy_marked()
@@ -291,7 +291,7 @@ public:
         d_marked_for_death.clear();
     }
 
-    auto marked_entities() -> std::span<const apx::entity>
+    auto marked_entities() const -> const std::unordered_set<apx::entity>&
     {
         return d_marked_for_death;
     }

--- a/src/core/debug.cpp
+++ b/src/core/debug.cpp
@@ -4,7 +4,11 @@ namespace sand {
 
 void draw_circle(b2Vec2 centre, float radius, b2HexColor colour, void* context)
 {
+    auto& renderer = *static_cast<shape_renderer*>(context);
+    const auto c = from_hex(colour);
+    const auto r = physics_to_pixel(radius);
 
+    renderer.draw_annulus(physics_to_pixel(centre), c, r - 1.0f, r);
 }
 
 void draw_point(b2Vec2 p, float size, b2HexColor colour, void* context)
@@ -45,7 +49,6 @@ void draw_solid_circle(b2Transform transform, float radius, b2HexColor colour, v
 
 void draw_solid_polygon(b2Transform transform, const b2Vec2* vertices, int vertexCount, float radius, b2HexColor colour, void* context)
 {
-
 }
 
 void draw_string(b2Vec2 p, const char* s, b2HexColor colour, void* context)
@@ -60,22 +63,7 @@ void draw_transform(b2Transform transform, void* context)
 
 
 #if 0
-physics_debug_draw::physics_debug_draw(shape_renderer* s) : d_renderer{s} {
-    SetFlags(b2Draw::e_shapeBit);
-}
 
-void physics_debug_draw::DrawPolygon(const b2Vec2* vertices, int32 vertexCount, const b2Color& color)
-{
-    assert(vertexCount > 1);
-    for (std::size_t i = 0; i < vertexCount - 1; ++i) {
-        const auto p1 = physics_to_pixel(vertices[i]);
-        const auto p2 = physics_to_pixel(vertices[i + 1]);
-        d_renderer->draw_line(p1, p2, {color.r, color.g, color.b, 1.0}, 1);
-    }
-    const auto p1 = physics_to_pixel(vertices[vertexCount - 1]);
-    const auto p2 = physics_to_pixel(vertices[0]);
-    d_renderer->draw_line(p1, p2, {color.r, color.g, color.b, 1.0}, 1);
-}
 
 void physics_debug_draw::DrawSolidPolygon(const b2Vec2* vertices, int32 vertexCount, const b2Color& color)
 {

--- a/src/core/debug.cpp
+++ b/src/core/debug.cpp
@@ -2,6 +2,7 @@
 
 namespace sand {
 
+#if 0
 physics_debug_draw::physics_debug_draw(shape_renderer* s) : d_renderer{s} {
     SetFlags(b2Draw::e_shapeBit);
 }
@@ -59,5 +60,6 @@ void physics_debug_draw::DrawPoint(const b2Vec2& p, float size, const b2Color& c
         2.0f
     );
 }
+#endif
 
 }

--- a/src/core/debug.cpp
+++ b/src/core/debug.cpp
@@ -13,7 +13,8 @@ void draw_circle(b2Vec2 centre, float radius, b2HexColor colour, void* context)
 
 void draw_point(b2Vec2 p, float size, b2HexColor colour, void* context)
 {
-
+    auto& renderer = *static_cast<shape_renderer*>(context);
+    renderer.draw_circle(physics_to_pixel(p), from_hex(colour), 2.0f);
 }
 
 void draw_polygon(const b2Vec2* vertices, int vertexCount, b2HexColor colour, void* context)
@@ -62,35 +63,5 @@ void draw_transform(b2Transform transform, void* context)
 {
 
 }
-
-
-#if 0
-
-
-void physics_debug_draw::DrawSolidCircle(const b2Vec2& center, float radius, const b2Vec2& axis, const b2Color& color)
-{
-    DrawCircle(center, radius, color);
-}
-
-void physics_debug_draw::DrawSegment(const b2Vec2& bp1, const b2Vec2& bp2, const b2Color& color)
-{
-    const auto p1 = physics_to_pixel(bp1);
-    const auto p2 = physics_to_pixel(bp2);
-    d_renderer->draw_line(p1, p2, {color.r, color.g, color.b, 1.0}, 1);
-}
-
-void physics_debug_draw::DrawTransform(const b2Transform& xf)
-{
-}
-
-void physics_debug_draw::DrawPoint(const b2Vec2& p, float size, const b2Color& color)
-{
-    d_renderer->draw_circle(
-        physics_to_pixel(p),
-        {color.r, color.g, color.b, 1.0},
-        2.0f
-    );
-}
-#endif
 
 }

--- a/src/core/debug.cpp
+++ b/src/core/debug.cpp
@@ -34,7 +34,8 @@ void draw_polygon(const b2Vec2* vertices, int vertexCount, b2HexColor colour, vo
 
 void draw_segment(b2Vec2 p1, b2Vec2 p2, b2HexColor colour, void* context)
 {
-
+    auto& renderer = *static_cast<shape_renderer*>(context);
+    renderer.draw_line(physics_to_pixel(p1), physics_to_pixel(p2), from_hex(colour), 2.0f);
 }
 
 void draw_solid_capsule(b2Vec2 p1, b2Vec2 p2, float radius, b2HexColor colour, void* context)

--- a/src/core/debug.cpp
+++ b/src/core/debug.cpp
@@ -44,11 +44,12 @@ void draw_solid_capsule(b2Vec2 p1, b2Vec2 p2, float radius, b2HexColor colour, v
 
 void draw_solid_circle(b2Transform transform, float radius, b2HexColor colour, void* context)
 {
-
+    draw_circle(transform.p, radius, colour, context);
 }
 
 void draw_solid_polygon(b2Transform transform, const b2Vec2* vertices, int vertexCount, float radius, b2HexColor colour, void* context)
 {
+    draw_polygon(vertices, vertexCount, colour, context);
 }
 
 void draw_string(b2Vec2 p, const char* s, b2HexColor colour, void* context)
@@ -64,22 +65,6 @@ void draw_transform(b2Transform transform, void* context)
 
 #if 0
 
-
-void physics_debug_draw::DrawSolidPolygon(const b2Vec2* vertices, int32 vertexCount, const b2Color& color)
-{
-    DrawPolygon(vertices, vertexCount, color);
-}
-
-void physics_debug_draw::DrawCircle(const b2Vec2& center, float radius, const b2Color& color)
-{
-    const auto r = physics_to_pixel(radius);
-    d_renderer->draw_annulus(
-        physics_to_pixel(center),
-        {color.r, color.g, color.b, 1.0},
-        r - 1.0f,
-        r
-    );
-}
 
 void physics_debug_draw::DrawSolidCircle(const b2Vec2& center, float radius, const b2Vec2& axis, const b2Color& color)
 {

--- a/src/core/debug.cpp
+++ b/src/core/debug.cpp
@@ -2,6 +2,63 @@
 
 namespace sand {
 
+void draw_circle(b2Vec2 centre, float radius, b2HexColor colour, void* context)
+{
+
+}
+
+void draw_point(b2Vec2 p, float size, b2HexColor colour, void* context)
+{
+
+}
+
+void draw_polygon(const b2Vec2* vertices, int vertexCount, b2HexColor colour, void* context)
+{
+    assert(vertexCount > 1);
+    auto& renderer = *static_cast<shape_renderer*>(context);
+    const auto c = from_hex(colour);
+
+    for (std::size_t i = 0; i < vertexCount - 1; ++i) {
+        const auto p1 = physics_to_pixel(vertices[i]);
+        const auto p2 = physics_to_pixel(vertices[i + 1]);
+        renderer.draw_line(p1, p2, c, 1);
+    }
+    const auto p1 = physics_to_pixel(vertices[vertexCount - 1]);
+    const auto p2 = physics_to_pixel(vertices[0]);
+    renderer.draw_line(p1, p2, c, 1);
+}
+
+void draw_segment(b2Vec2 p1, b2Vec2 p2, b2HexColor colour, void* context)
+{
+
+}
+
+void draw_solid_capsule(b2Vec2 p1, b2Vec2 p2, float radius, b2HexColor colour, void* context)
+{
+
+}
+
+void draw_solid_circle(b2Transform transform, float radius, b2HexColor colour, void* context)
+{
+
+}
+
+void draw_solid_polygon(b2Transform transform, const b2Vec2* vertices, int vertexCount, float radius, b2HexColor colour, void* context)
+{
+
+}
+
+void draw_string(b2Vec2 p, const char* s, b2HexColor colour, void* context)
+{
+
+}
+
+void draw_transform(b2Transform transform, void* context)
+{
+
+}
+
+
 #if 0
 physics_debug_draw::physics_debug_draw(shape_renderer* s) : d_renderer{s} {
     SetFlags(b2Draw::e_shapeBit);

--- a/src/core/debug.hpp
+++ b/src/core/debug.hpp
@@ -6,6 +6,16 @@
 
 namespace sand {
 
+void draw_circle(b2Vec2 centre, float radius, b2HexColor colour, void* context);
+void draw_point(b2Vec2 p, float size, b2HexColor colour, void* context);
+void draw_polygon(const b2Vec2* vertices, int vertexCount, b2HexColor colour, void* context);
+void draw_segment(b2Vec2 p1, b2Vec2 p2, b2HexColor colour, void* context);
+void draw_solid_capsule(b2Vec2 p1, b2Vec2 p2, float radius, b2HexColor colour, void* context);
+void draw_solid_circle(b2Transform transform, float radius, b2HexColor colour, void* context);
+void draw_solid_polygon(b2Transform transform, const b2Vec2* vertices, int vertexCount, float radius, b2HexColor colour, void* context);
+void draw_string(b2Vec2 p, const char* s, b2HexColor colour, void* context);
+void draw_transform(b2Transform transform, void* context);
+
 #if 0
 class physics_debug_draw : public b2Draw
 {

--- a/src/core/debug.hpp
+++ b/src/core/debug.hpp
@@ -16,22 +16,4 @@ void draw_solid_polygon(b2Transform transform, const b2Vec2* vertices, int verte
 void draw_string(b2Vec2 p, const char* s, b2HexColor colour, void* context);
 void draw_transform(b2Transform transform, void* context);
 
-#if 0
-class physics_debug_draw : public b2Draw
-{
-    shape_renderer* d_renderer;
-
-public:
-    physics_debug_draw(shape_renderer* s);
-    
-    void DrawPolygon(const b2Vec2* vertices, int32 vertexCount, const b2Color& color) override;
-    void DrawSolidPolygon(const b2Vec2* vertices, int32 vertexCount, const b2Color& color) override;
-    void DrawCircle(const b2Vec2& center, float radius, const b2Color& color) override;
-	void DrawSolidCircle(const b2Vec2& center, float radius, const b2Vec2& axis, const b2Color& color) override;
-	void DrawSegment(const b2Vec2& bp1, const b2Vec2& bp2, const b2Color& color);
-	void DrawTransform(const b2Transform& xf) override;
-	void DrawPoint(const b2Vec2& p, float size, const b2Color& color) override;
-};
-#endif
-
 }

--- a/src/core/debug.hpp
+++ b/src/core/debug.hpp
@@ -6,6 +6,7 @@
 
 namespace sand {
 
+#if 0
 class physics_debug_draw : public b2Draw
 {
     shape_renderer* d_renderer;
@@ -21,5 +22,6 @@ public:
 	void DrawTransform(const b2Transform& xf) override;
 	void DrawPoint(const b2Vec2& p, float size, const b2Color& color) override;
 };
+#endif
 
 }

--- a/src/core/entity.cpp
+++ b/src/core/entity.cpp
@@ -23,7 +23,7 @@ auto add_player(registry& entities, b2WorldId world, pixel_pos position) -> enti
 
     body_comp.body = b2CreateBody(world, &def);
     b2Body_SetMassData(body_comp.body, b2MassData{.mass = 80});
-    b2Body_SetUserData(body_comp.body, (void*)(std::uintptr_t)e); // TODO: Make this safer!!
+    b2Body_SetUserData(body_comp.body, to_user_data(e));
 
     // Set up main body fixture
     {
@@ -91,7 +91,7 @@ auto add_enemy(registry& entities, b2WorldId world, pixel_pos position) -> entit
     def.position = pixel_to_physics(position);
 
     body_comp.body = b2CreateBody(world, &def);
-    b2Body_SetUserData(body_comp.body, (void*)(std::uintptr_t)e);
+    b2Body_SetUserData(body_comp.body, to_user_data(e));
     b2Body_SetMassData(body_comp.body, b2MassData{.mass = 10});
 
     // Set up main body fixture
@@ -138,5 +138,16 @@ auto ecs_entity_centre(const registry& entities, entity e) -> glm::vec2
     assert(b2Body_IsValid(entities.get<body_component>(e).body));
     return physics_to_pixel(b2Body_GetPosition(entities.get<body_component>(e).body));
 }
+
+auto to_user_data(entity e) -> void*
+{
+    return std::bit_cast<void*>(e);
+}
+
+auto from_user_data(void* data) -> entity
+{
+    return std::bit_cast<entity>(data);
+}
+
 
 }

--- a/src/core/entity.cpp
+++ b/src/core/entity.cpp
@@ -18,57 +18,6 @@ namespace sand {
 //        contact->ResetFriction();
 //    }
 //}
-//
-//
-//void contact_listener::end_contact(b2Fixture* curr, b2Fixture* other)
-//{
-//    const auto curr_entity = static_cast<entity>(curr->GetBody()->GetUserData().pointer);
-//    const auto other_entity = static_cast<entity>(other->GetBody()->GetUserData().pointer);
-//    
-//    if (!d_level->entities.valid(curr_entity)) return;
-//
-//    if (d_level->entities.has<player_component>(curr_entity)
-//        && !other->IsSensor())
-//    {
-//        auto& comp = d_level->entities.get<player_component>(curr_entity);
-//        if (comp.foot_sensor && curr == comp.foot_sensor) {
-//            comp.floors.erase(other);
-//        }
-//        if (comp.left_sensor && curr == comp.left_sensor) {
-//            --comp.num_left_contacts;
-//        }
-//        if (comp.right_sensor && curr == comp.right_sensor) {
-//            --comp.num_right_contacts;
-//        }
-//    }
-//    
-//    if (d_level->entities.has<enemy_component>(curr_entity) 
-//        && d_level->entities.valid(other_entity))
-//    {
-//        auto& comp = d_level->entities.get<enemy_component>(curr_entity);
-//        if (comp.proximity_sensor && curr == comp.proximity_sensor && d_level->entities.valid(other_entity)) {
-//            comp.nearby_entities.erase(other_entity);
-//        }
-//    }
-//}
-//
-//void contact_listener::BeginContact(b2Contact* contact)
-//{
-//    const auto a = contact->GetFixtureA();
-//    const auto b = contact->GetFixtureB();
-//
-//    begin_contact(a, b);
-//    begin_contact(b, a);
-//}
-//
-//void contact_listener::EndContact(b2Contact* contact)
-//{
-//    const auto a = contact->GetFixtureA();
-//    const auto b = contact->GetFixtureB();
-//
-//    end_contact(a, b);
-//    end_contact(b, a);
-//}
 
 auto add_player(registry& entities, b2WorldId world, pixel_pos position) -> entity
 {

--- a/src/core/entity.cpp
+++ b/src/core/entity.cpp
@@ -2,115 +2,115 @@
 #include "world.hpp"
 #include "explosion.hpp"
 
-#include <box2d/b2_body.h>
+#include <box2d/box2d.h>
 
 namespace sand {
 
-void contact_listener::PreSolve(b2Contact* contact, const b2Manifold*) 
-{
-    const auto a = static_cast<entity>(contact->GetFixtureA()->GetBody()->GetUserData().pointer);
-    const auto b = static_cast<entity>(contact->GetFixtureB()->GetBody()->GetUserData().pointer);
+//void contact_listener::PreSolve(b2Contact* contact, const b2Manifold*) 
+//{
+//    const auto a = static_cast<entity>(contact->GetFixtureA()->GetBody()->GetUserData().pointer);
+//    const auto b = static_cast<entity>(contact->GetFixtureB()->GetBody()->GetUserData().pointer);
+//
+//    const auto a_is_player = d_level->entities.valid(a) && d_level->entities.has<player_component>(a);
+//    const auto b_is_player = d_level->entities.valid(b) && d_level->entities.has<player_component>(b);
+//
+//    if (a_is_player || b_is_player) {
+//        contact->ResetFriction();
+//    }
+//}
+//
+//void contact_listener::begin_contact(b2Fixture* curr, b2Fixture* other)
+//{
+//    const auto curr_entity = static_cast<entity>(curr->GetBody()->GetUserData().pointer);
+//    const auto other_entity = static_cast<entity>(other->GetBody()->GetUserData().pointer);
+//    
+//    if (!d_level->entities.valid(curr_entity)) return;
+//
+//    if (d_level->entities.has<grenade_component>(curr_entity) 
+//        && !other->IsSensor()
+//        && (!d_level->entities.valid(other_entity) || !d_level->entities.has<player_component>(other_entity)))
+//    {
+//        d_level->entities.mark_for_death(curr_entity);
+//        const auto pos = ecs_entity_centre(d_level->entities, curr_entity);
+//        apply_explosion(d_level->pixels, pixel_pos::from_ivec2(pos), explosion{.min_radius=5, .max_radius=10, .scorch=15});   
+//    }
+//    
+//    if (d_level->entities.has<player_component>(curr_entity)
+//        && !other->IsSensor())
+//    {
+//        auto& comp = d_level->entities.get<player_component>(curr_entity);
+//        if (comp.foot_sensor && curr == comp.foot_sensor) {
+//            comp.floors.insert(other);
+//        }
+//        if (comp.left_sensor && curr == comp.left_sensor) {
+//            ++comp.num_left_contacts;
+//        }
+//        if (comp.right_sensor && curr == comp.right_sensor) {
+//            ++comp.num_right_contacts;
+//        }
+//    }
+//    
+//    if (d_level->entities.has<enemy_component>(curr_entity) 
+//        && d_level->entities.valid(other_entity))
+//    {
+//        auto& comp = d_level->entities.get<enemy_component>(curr_entity);
+//        if (comp.proximity_sensor && curr == comp.proximity_sensor && d_level->entities.valid(other_entity)) {
+//            comp.nearby_entities.insert(other_entity);
+//        }
+//    }
+//}
+//
+//void contact_listener::end_contact(b2Fixture* curr, b2Fixture* other)
+//{
+//    const auto curr_entity = static_cast<entity>(curr->GetBody()->GetUserData().pointer);
+//    const auto other_entity = static_cast<entity>(other->GetBody()->GetUserData().pointer);
+//    
+//    if (!d_level->entities.valid(curr_entity)) return;
+//
+//    if (d_level->entities.has<player_component>(curr_entity)
+//        && !other->IsSensor())
+//    {
+//        auto& comp = d_level->entities.get<player_component>(curr_entity);
+//        if (comp.foot_sensor && curr == comp.foot_sensor) {
+//            comp.floors.erase(other);
+//        }
+//        if (comp.left_sensor && curr == comp.left_sensor) {
+//            --comp.num_left_contacts;
+//        }
+//        if (comp.right_sensor && curr == comp.right_sensor) {
+//            --comp.num_right_contacts;
+//        }
+//    }
+//    
+//    if (d_level->entities.has<enemy_component>(curr_entity) 
+//        && d_level->entities.valid(other_entity))
+//    {
+//        auto& comp = d_level->entities.get<enemy_component>(curr_entity);
+//        if (comp.proximity_sensor && curr == comp.proximity_sensor && d_level->entities.valid(other_entity)) {
+//            comp.nearby_entities.erase(other_entity);
+//        }
+//    }
+//}
+//
+//void contact_listener::BeginContact(b2Contact* contact)
+//{
+//    const auto a = contact->GetFixtureA();
+//    const auto b = contact->GetFixtureB();
+//
+//    begin_contact(a, b);
+//    begin_contact(b, a);
+//}
+//
+//void contact_listener::EndContact(b2Contact* contact)
+//{
+//    const auto a = contact->GetFixtureA();
+//    const auto b = contact->GetFixtureB();
+//
+//    end_contact(a, b);
+//    end_contact(b, a);
+//}
 
-    const auto a_is_player = d_level->entities.valid(a) && d_level->entities.has<player_component>(a);
-    const auto b_is_player = d_level->entities.valid(b) && d_level->entities.has<player_component>(b);
-
-    if (a_is_player || b_is_player) {
-        contact->ResetFriction();
-    }
-}
-
-void contact_listener::begin_contact(b2Fixture* curr, b2Fixture* other)
-{
-    const auto curr_entity = static_cast<entity>(curr->GetBody()->GetUserData().pointer);
-    const auto other_entity = static_cast<entity>(other->GetBody()->GetUserData().pointer);
-    
-    if (!d_level->entities.valid(curr_entity)) return;
-
-    if (d_level->entities.has<grenade_component>(curr_entity) 
-        && !other->IsSensor()
-        && (!d_level->entities.valid(other_entity) || !d_level->entities.has<player_component>(other_entity)))
-    {
-        d_level->entities.mark_for_death(curr_entity);
-        const auto pos = ecs_entity_centre(d_level->entities, curr_entity);
-        apply_explosion(d_level->pixels, pixel_pos::from_ivec2(pos), explosion{.min_radius=5, .max_radius=10, .scorch=15});   
-    }
-    
-    if (d_level->entities.has<player_component>(curr_entity)
-        && !other->IsSensor())
-    {
-        auto& comp = d_level->entities.get<player_component>(curr_entity);
-        if (comp.foot_sensor && curr == comp.foot_sensor) {
-            comp.floors.insert(other);
-        }
-        if (comp.left_sensor && curr == comp.left_sensor) {
-            ++comp.num_left_contacts;
-        }
-        if (comp.right_sensor && curr == comp.right_sensor) {
-            ++comp.num_right_contacts;
-        }
-    }
-    
-    if (d_level->entities.has<enemy_component>(curr_entity) 
-        && d_level->entities.valid(other_entity))
-    {
-        auto& comp = d_level->entities.get<enemy_component>(curr_entity);
-        if (comp.proximity_sensor && curr == comp.proximity_sensor && d_level->entities.valid(other_entity)) {
-            comp.nearby_entities.insert(other_entity);
-        }
-    }
-}
-
-void contact_listener::end_contact(b2Fixture* curr, b2Fixture* other)
-{
-    const auto curr_entity = static_cast<entity>(curr->GetBody()->GetUserData().pointer);
-    const auto other_entity = static_cast<entity>(other->GetBody()->GetUserData().pointer);
-    
-    if (!d_level->entities.valid(curr_entity)) return;
-
-    if (d_level->entities.has<player_component>(curr_entity)
-        && !other->IsSensor())
-    {
-        auto& comp = d_level->entities.get<player_component>(curr_entity);
-        if (comp.foot_sensor && curr == comp.foot_sensor) {
-            comp.floors.erase(other);
-        }
-        if (comp.left_sensor && curr == comp.left_sensor) {
-            --comp.num_left_contacts;
-        }
-        if (comp.right_sensor && curr == comp.right_sensor) {
-            --comp.num_right_contacts;
-        }
-    }
-    
-    if (d_level->entities.has<enemy_component>(curr_entity) 
-        && d_level->entities.valid(other_entity))
-    {
-        auto& comp = d_level->entities.get<enemy_component>(curr_entity);
-        if (comp.proximity_sensor && curr == comp.proximity_sensor && d_level->entities.valid(other_entity)) {
-            comp.nearby_entities.erase(other_entity);
-        }
-    }
-}
-
-void contact_listener::BeginContact(b2Contact* contact)
-{
-    const auto a = contact->GetFixtureA();
-    const auto b = contact->GetFixtureB();
-
-    begin_contact(a, b);
-    begin_contact(b, a);
-}
-
-void contact_listener::EndContact(b2Contact* contact)
-{
-    const auto a = contact->GetFixtureA();
-    const auto b = contact->GetFixtureB();
-
-    end_contact(a, b);
-    end_contact(b, a);
-}
-
-auto add_player(registry& entities, b2World& world, pixel_pos position) -> entity
+auto add_player(registry& entities, b2WorldId world, pixel_pos position) -> entity
 {
     const auto e = entities.create();
     auto& body_comp = entities.emplace<body_component>(e);
@@ -119,71 +119,61 @@ auto add_player(registry& entities, b2World& world, pixel_pos position) -> entit
     life_comp.spawn_point = position;
 
     // Create player body
-    b2BodyDef bodyDef;
-    bodyDef.type = b2_dynamicBody;
-    bodyDef.fixedRotation = true;
-    bodyDef.linearDamping = 1.0f;
-    const auto pos = pixel_to_physics(position);
-    bodyDef.position.Set(pos.x, pos.y);
-    body_comp.body = world.CreateBody(&bodyDef);
-    body_comp.body->GetUserData().pointer = static_cast<std::uintptr_t>(e);
-    b2MassData md;
-    md.mass = 80;
-    body_comp.body->SetMassData(&md);
+    b2BodyDef def;
+    def.type = b2_dynamicBody;
+    def.fixedRotation = true;
+    def.linearDamping = 1.0f;
+    def.position = pixel_to_physics(position);
+
+    body_comp.body = b2CreateBody(world, &def);
+    b2Body_SetMassData(body_comp.body, b2MassData{.mass = 80});
+    b2Body_SetUserData(body_comp.body, (void*)(std::uintptr_t)e); // TODO: Make this safer!!
 
     // Set up main body fixture
     {
         const auto half_extents = pixel_to_physics(pixel_pos{5, 10});
-        b2PolygonShape shape;
-        shape.SetAsBox(half_extents.x, half_extents.y);
+        b2Polygon box = b2MakeBox(half_extents.x, half_extents.y);
 
-        b2FixtureDef fixtureDef;
-        fixtureDef.shape = &shape;
-        fixtureDef.density = 1.0f;
-        fixtureDef.friction = 1.0f;
-        body_comp.body_fixture = body_comp.body->CreateFixture(&fixtureDef);
+        b2ShapeDef def = b2DefaultShapeDef();
+        def.density = 1.0f;
+        def.material.friction = 1.0f;
+        body_comp.body_fixture = b2CreatePolygonShape(body_comp.body, &def, &box);
     }
     
     // Set up foot sensor
     {
         const auto half_extents = pixel_to_physics(pixel_pos{2, 4});
-        b2PolygonShape shape;
-        shape.SetAsBox(half_extents.x, half_extents.y, pixel_to_physics(pixel_pos{0, 10}), 0);
+        b2Polygon box = b2MakeOffsetBox(half_extents.x, half_extents.y, pixel_to_physics(pixel_pos{0, 10}), b2Rot(0));
         
-        b2FixtureDef fixtureDef;
-        fixtureDef.shape = &shape;
-        fixtureDef.isSensor = true;
-        player_comp.foot_sensor = body_comp.body->CreateFixture(&fixtureDef);
+        b2ShapeDef def = b2DefaultShapeDef();
+        def.isSensor = true;
+        player_comp.foot_sensor = b2CreatePolygonShape(body_comp.body, &def, &box);
     }
 
      // Set up left sensor
      {
         const auto half_extents = pixel_to_physics(pixel_pos{1, 9});
-        b2PolygonShape shape;
-        shape.SetAsBox(half_extents.x, half_extents.y, pixel_to_physics(pixel_pos{-5, 0}), 0);
+        b2Polygon box = b2MakeOffsetBox(half_extents.x, half_extents.y, pixel_to_physics(pixel_pos{-5, 0}), b2Rot(0));
         
-        b2FixtureDef fixtureDef;
-        fixtureDef.shape = &shape;
-        fixtureDef.isSensor = true;
-        player_comp.left_sensor = body_comp.body->CreateFixture(&fixtureDef);
+        b2ShapeDef def = b2DefaultShapeDef();
+        def.isSensor = true;
+        player_comp.left_sensor = b2CreatePolygonShape(body_comp.body, &def, &box);
     }
 
     // Set up right sensor
     {
         const auto half_extents = pixel_to_physics(pixel_pos{1, 9});
-        b2PolygonShape shape;
-        shape.SetAsBox(half_extents.x, half_extents.y, pixel_to_physics(pixel_pos{5, 0}), 0);
+        b2Polygon box = b2MakeOffsetBox(half_extents.x, half_extents.y, pixel_to_physics(pixel_pos{5, 0}), b2Rot(0));
         
-        b2FixtureDef fixtureDef;
-        fixtureDef.shape = &shape;
-        fixtureDef.isSensor = true;
-        player_comp.right_sensor = body_comp.body->CreateFixture(&fixtureDef);
+        b2ShapeDef def = b2DefaultShapeDef();
+        def.isSensor = true;
+        player_comp.right_sensor = b2CreatePolygonShape(body_comp.body, &def, &box);
     }
 
     return e;
 }
 
-auto add_enemy(registry& entities, b2World& world, pixel_pos position) -> entity
+auto add_enemy(registry& entities, b2WorldId world, pixel_pos position) -> entity
 {
     const auto e = entities.create();
     auto& body_comp = entities.emplace<body_component>(e);
@@ -193,41 +183,37 @@ auto add_enemy(registry& entities, b2World& world, pixel_pos position) -> entity
     life_comp.spawn_point = position;
 
     // Create player body
-    b2BodyDef bodyDef;
-    bodyDef.allowSleep = false;
-    bodyDef.gravityScale = 0.0f;
-    bodyDef.type = b2_dynamicBody;
-    bodyDef.fixedRotation = true;
-    bodyDef.linearDamping = 1.0f;
-    const auto pos = pixel_to_physics(position);
-    bodyDef.position.Set(pos.x, pos.y);
-    body_comp.body = world.CreateBody(&bodyDef);
-    body_comp.body->GetUserData().pointer = static_cast<std::uintptr_t>(e);
-    b2MassData md;
-    md.mass = 10;
-    body_comp.body->SetMassData(&md);
+    b2BodyDef def;
+    def.type = b2_dynamicBody;
+    def.enableSleep = false;
+    def.gravityScale = 0.0f;
+    def.fixedRotation = true;
+    def.linearDamping = 1.0f;
+    def.position = pixel_to_physics(position);
+
+    body_comp.body = b2CreateBody(world, &def);
+    b2Body_SetUserData(body_comp.body, (void*)(std::uintptr_t)e);
+    b2Body_SetMassData(body_comp.body, b2MassData{.mass = 10});
 
     // Set up main body fixture
     {
-        b2CircleShape circleShape;
-        circleShape.m_radius = pixel_to_physics(4.0f);
+        b2Circle circle;
+        circle.radius = pixel_to_physics(4.0f);
 
-        b2FixtureDef fixtureDef;
-        fixtureDef.shape = &circleShape;
-        fixtureDef.density = 1.0f;
-        fixtureDef.friction = 0.5f;
-        body_comp.body_fixture = body_comp.body->CreateFixture(&fixtureDef);
+        b2ShapeDef def = b2DefaultShapeDef();
+        def.density = 1.0f;
+        def.material.friction = 0.5f;
+        body_comp.body_fixture = b2CreateCircleShape(body_comp.body, &def, &circle);
     }
 
     // Set up proximity sensor
     {
-        b2CircleShape circleShape;
-        circleShape.m_radius = pixel_to_physics(100.0f);
+        b2Circle circle;
+        circle.radius = pixel_to_physics(100.0f);
         
-        b2FixtureDef fixtureDef;
-        fixtureDef.shape = &circleShape;
-        fixtureDef.isSensor = true;
-        enemy_comp.proximity_sensor = body_comp.body->CreateFixture(&fixtureDef);
+        b2ShapeDef def = b2DefaultShapeDef();
+        def.isSensor = true;
+        enemy_comp.proximity_sensor = b2CreateCircleShape(body_comp.body, &def, &circle);
     }
 
     return e;
@@ -241,15 +227,15 @@ auto ecs_entity_respawn(const registry& entities, entity e) -> void
     auto& body_comp = entities.get<body_component>(e);
     auto& life_comp = entities.get<life_component>(e);
 
-    body_comp.body->SetTransform(pixel_to_physics(life_comp.spawn_point), 0);
-    body_comp.body->SetLinearVelocity({0, 0});
-    body_comp.body->SetAwake(true);
+    b2Body_SetTransform(body_comp.body, pixel_to_physics(life_comp.spawn_point), b2Rot(0));
+    b2Body_SetLinearVelocity(body_comp.body, {0, 0});
+    b2Body_SetAwake(body_comp.body, true);
 }
 
 auto ecs_entity_centre(const registry& entities, entity e) -> glm::vec2
 {
     assert(entities.has<body_component>(e));
-    return physics_to_pixel(entities.get<body_component>(e).body->GetPosition());
+    return physics_to_pixel(b2Body_GetPosition(entities.get<body_component>(e).body));
 }
 
 }

--- a/src/core/entity.cpp
+++ b/src/core/entity.cpp
@@ -6,19 +6,6 @@
 
 namespace sand {
 
-//void contact_listener::PreSolve(b2Contact* contact, const b2Manifold*) 
-//{
-//    const auto a = static_cast<entity>(contact->GetFixtureA()->GetBody()->GetUserData().pointer);
-//    const auto b = static_cast<entity>(contact->GetFixtureB()->GetBody()->GetUserData().pointer);
-//
-//    const auto a_is_player = d_level->entities.valid(a) && d_level->entities.has<player_component>(a);
-//    const auto b_is_player = d_level->entities.valid(b) && d_level->entities.has<player_component>(b);
-//
-//    if (a_is_player || b_is_player) {
-//        contact->ResetFriction();
-//    }
-//}
-
 auto add_player(registry& entities, b2WorldId world, pixel_pos position) -> entity
 {
     const auto e = entities.create();

--- a/src/core/entity.cpp
+++ b/src/core/entity.cpp
@@ -119,7 +119,7 @@ auto add_player(registry& entities, b2WorldId world, pixel_pos position) -> enti
     life_comp.spawn_point = position;
 
     // Create player body
-    b2BodyDef def;
+    b2BodyDef def = b2DefaultBodyDef();
     def.type = b2_dynamicBody;
     def.fixedRotation = true;
     def.linearDamping = 1.0f;
@@ -143,7 +143,10 @@ auto add_player(registry& entities, b2WorldId world, pixel_pos position) -> enti
     // Set up foot sensor
     {
         const auto half_extents = pixel_to_physics(pixel_pos{2, 4});
-        b2Polygon box = b2MakeOffsetBox(half_extents.x, half_extents.y, pixel_to_physics(pixel_pos{0, 10}), b2Rot(0));
+        b2Polygon box = b2MakeBox(half_extents.x, half_extents.y);
+        b2Transform t = {};
+        t.p = pixel_to_physics(pixel_pos{0, 10});
+        b2TransformPolygon(t, &box);
         
         b2ShapeDef def = b2DefaultShapeDef();
         def.isSensor = true;
@@ -153,7 +156,10 @@ auto add_player(registry& entities, b2WorldId world, pixel_pos position) -> enti
      // Set up left sensor
      {
         const auto half_extents = pixel_to_physics(pixel_pos{1, 9});
-        b2Polygon box = b2MakeOffsetBox(half_extents.x, half_extents.y, pixel_to_physics(pixel_pos{-5, 0}), b2Rot(0));
+        b2Polygon box = b2MakeBox(half_extents.x, half_extents.y);
+        b2Transform t = {};
+        t.p = pixel_to_physics(pixel_pos{-5, 0});
+        b2TransformPolygon(t, &box);
         
         b2ShapeDef def = b2DefaultShapeDef();
         def.isSensor = true;
@@ -163,7 +169,10 @@ auto add_player(registry& entities, b2WorldId world, pixel_pos position) -> enti
     // Set up right sensor
     {
         const auto half_extents = pixel_to_physics(pixel_pos{1, 9});
-        b2Polygon box = b2MakeOffsetBox(half_extents.x, half_extents.y, pixel_to_physics(pixel_pos{5, 0}), b2Rot(0));
+        b2Polygon box = b2MakeBox(half_extents.x, half_extents.y);
+        b2Transform t = {};
+        t.p = pixel_to_physics(pixel_pos{5, 0});
+        b2TransformPolygon(t, &box);
         
         b2ShapeDef def = b2DefaultShapeDef();
         def.isSensor = true;
@@ -183,7 +192,7 @@ auto add_enemy(registry& entities, b2WorldId world, pixel_pos position) -> entit
     life_comp.spawn_point = position;
 
     // Create player body
-    b2BodyDef def;
+    b2BodyDef def = b2DefaultBodyDef();
     def.type = b2_dynamicBody;
     def.enableSleep = false;
     def.gravityScale = 0.0f;
@@ -197,18 +206,18 @@ auto add_enemy(registry& entities, b2WorldId world, pixel_pos position) -> entit
 
     // Set up main body fixture
     {
-        b2Circle circle;
+        b2Circle circle = {};
         circle.radius = pixel_to_physics(4.0f);
 
-        b2ShapeDef def = b2DefaultShapeDef();
-        def.density = 1.0f;
-        def.material.friction = 0.5f;
-        body_comp.body_fixture = b2CreateCircleShape(body_comp.body, &def, &circle);
+        b2ShapeDef def2 = b2DefaultShapeDef();
+        def2.density = 1.0f;
+        def2.material.friction = 0.5f;
+        body_comp.body_fixture = b2CreateCircleShape(body_comp.body, &def2, &circle);
     }
 
     // Set up proximity sensor
     {
-        b2Circle circle;
+        b2Circle circle = {};
         circle.radius = pixel_to_physics(100.0f);
         
         b2ShapeDef def = b2DefaultShapeDef();
@@ -235,6 +244,7 @@ auto ecs_entity_respawn(const registry& entities, entity e) -> void
 auto ecs_entity_centre(const registry& entities, entity e) -> glm::vec2
 {
     assert(entities.has<body_component>(e));
+    assert(b2Body_IsValid(entities.get<body_component>(e).body));
     return physics_to_pixel(b2Body_GetPosition(entities.get<body_component>(e).body));
 }
 

--- a/src/core/entity.cpp
+++ b/src/core/entity.cpp
@@ -67,6 +67,7 @@ auto add_player(registry& entities, b2WorldId world, pixel_pos position) -> enti
         
         b2ShapeDef def = b2DefaultShapeDef();
         def.isSensor = true;
+        def.enableSensorEvents = true;
         player_comp.left_sensor = b2CreatePolygonShape(body_comp.body, &def, &box);
     }
 
@@ -77,6 +78,7 @@ auto add_player(registry& entities, b2WorldId world, pixel_pos position) -> enti
         
         b2ShapeDef def = b2DefaultShapeDef();
         def.isSensor = true;
+        def.enableSensorEvents = true;
         player_comp.right_sensor = b2CreatePolygonShape(body_comp.body, &def, &box);
     }
 
@@ -123,6 +125,7 @@ auto add_enemy(registry& entities, b2WorldId world, pixel_pos position) -> entit
         
         b2ShapeDef def = b2DefaultShapeDef();
         def.isSensor = true;
+        def.enableSensorEvents = true;
         enemy_comp.proximity_sensor = b2CreateCircleShape(body_comp.body, &def, &circle);
     }
 

--- a/src/core/entity.cpp
+++ b/src/core/entity.cpp
@@ -56,6 +56,7 @@ auto add_player(registry& entities, b2WorldId world, pixel_pos position) -> enti
         
         b2ShapeDef def = b2DefaultShapeDef();
         def.isSensor = true;
+        def.enableSensorEvents = true;
         player_comp.foot_sensor = b2CreatePolygonShape(body_comp.body, &def, &box);
     }
 

--- a/src/core/entity.cpp
+++ b/src/core/entity.cpp
@@ -19,46 +19,6 @@ namespace sand {
 //    }
 //}
 //
-//void contact_listener::begin_contact(b2Fixture* curr, b2Fixture* other)
-//{
-//    const auto curr_entity = static_cast<entity>(curr->GetBody()->GetUserData().pointer);
-//    const auto other_entity = static_cast<entity>(other->GetBody()->GetUserData().pointer);
-//    
-//    if (!d_level->entities.valid(curr_entity)) return;
-//
-//    if (d_level->entities.has<grenade_component>(curr_entity) 
-//        && !other->IsSensor()
-//        && (!d_level->entities.valid(other_entity) || !d_level->entities.has<player_component>(other_entity)))
-//    {
-//        d_level->entities.mark_for_death(curr_entity);
-//        const auto pos = ecs_entity_centre(d_level->entities, curr_entity);
-//        apply_explosion(d_level->pixels, pixel_pos::from_ivec2(pos), explosion{.min_radius=5, .max_radius=10, .scorch=15});   
-//    }
-//    
-//    if (d_level->entities.has<player_component>(curr_entity)
-//        && !other->IsSensor())
-//    {
-//        auto& comp = d_level->entities.get<player_component>(curr_entity);
-//        if (comp.foot_sensor && curr == comp.foot_sensor) {
-//            comp.floors.insert(other);
-//        }
-//        if (comp.left_sensor && curr == comp.left_sensor) {
-//            ++comp.num_left_contacts;
-//        }
-//        if (comp.right_sensor && curr == comp.right_sensor) {
-//            ++comp.num_right_contacts;
-//        }
-//    }
-//    
-//    if (d_level->entities.has<enemy_component>(curr_entity) 
-//        && d_level->entities.valid(other_entity))
-//    {
-//        auto& comp = d_level->entities.get<enemy_component>(curr_entity);
-//        if (comp.proximity_sensor && curr == comp.proximity_sensor && d_level->entities.valid(other_entity)) {
-//            comp.nearby_entities.insert(other_entity);
-//        }
-//    }
-//}
 //
 //void contact_listener::end_contact(b2Fixture* curr, b2Fixture* other)
 //{

--- a/src/core/entity.cpp
+++ b/src/core/entity.cpp
@@ -52,10 +52,7 @@ auto add_player(registry& entities, b2WorldId world, pixel_pos position) -> enti
     // Set up foot sensor
     {
         const auto half_extents = pixel_to_physics(pixel_pos{2, 4});
-        b2Polygon box = b2MakeBox(half_extents.x, half_extents.y);
-        b2Transform t = {};
-        t.p = pixel_to_physics(pixel_pos{0, 10});
-        b2TransformPolygon(t, &box);
+        b2Polygon box = b2MakeOffsetBox(half_extents.x, half_extents.y, pixel_to_physics(pixel_pos{0, 10}), b2MakeRot(0));
         
         b2ShapeDef def = b2DefaultShapeDef();
         def.isSensor = true;
@@ -65,10 +62,7 @@ auto add_player(registry& entities, b2WorldId world, pixel_pos position) -> enti
      // Set up left sensor
      {
         const auto half_extents = pixel_to_physics(pixel_pos{1, 9});
-        b2Polygon box = b2MakeBox(half_extents.x, half_extents.y);
-        b2Transform t = {};
-        t.p = pixel_to_physics(pixel_pos{-5, 0});
-        b2TransformPolygon(t, &box);
+        b2Polygon box = b2MakeOffsetBox(half_extents.x, half_extents.y, pixel_to_physics(pixel_pos{-5, 0}), b2MakeRot(0));
         
         b2ShapeDef def = b2DefaultShapeDef();
         def.isSensor = true;
@@ -78,10 +72,7 @@ auto add_player(registry& entities, b2WorldId world, pixel_pos position) -> enti
     // Set up right sensor
     {
         const auto half_extents = pixel_to_physics(pixel_pos{1, 9});
-        b2Polygon box = b2MakeBox(half_extents.x, half_extents.y);
-        b2Transform t = {};
-        t.p = pixel_to_physics(pixel_pos{5, 0});
-        b2TransformPolygon(t, &box);
+        b2Polygon box = b2MakeOffsetBox(half_extents.x, half_extents.y, pixel_to_physics(pixel_pos{5, 0}), b2MakeRot(0));
         
         b2ShapeDef def = b2DefaultShapeDef();
         def.isSensor = true;

--- a/src/core/entity.hpp
+++ b/src/core/entity.hpp
@@ -79,4 +79,10 @@ auto add_enemy(registry& entities, b2WorldId world, pixel_pos position) -> entit
 auto ecs_entity_respawn(const registry& entities, entity e) -> void;
 auto ecs_entity_centre(const registry& entities, entity e) -> glm::vec2;
 
+// Used for storing entity values in the user data. The point is not a valid
+// pointer! It just encodes the entity.
+static_assert(sizeof(entity) == sizeof(void*));
+auto to_user_data(entity e) -> void*;
+auto from_user_data(void* data) -> entity;
+
 }

--- a/src/core/entity.hpp
+++ b/src/core/entity.hpp
@@ -20,9 +20,7 @@ struct shape_id_equal
 {
     auto operator()(const b2ShapeId lhs, const b2ShapeId rhs) const -> bool
     {
-        return lhs.generation == rhs.generation
-            && lhs.index1 == rhs.index1
-            && lhs.world0 == rhs.world0;
+        return B2_ID_EQUALS(lhs, rhs);
     }
 };
 

--- a/src/core/entity.hpp
+++ b/src/core/entity.hpp
@@ -30,22 +30,6 @@ namespace sand {
 
 using entity = apx::entity;
 
-//class level;
-//class contact_listener : public b2ContactListener
-//{
-//    level* d_level;
-//
-//    void begin_contact(b2Fixture* curr, b2Fixture* other);
-//    void end_contact(b2Fixture* curr, b2Fixture* other);
-//
-//public:
-//    contact_listener(level* l) : d_level{l} {}
-//
-//    void PreSolve(b2Contact* contact, const b2Manifold* impulse) override;
-//    void BeginContact(b2Contact* contact) override;
-//    void EndContact(b2Contact* contact) override;
-//};
-
 struct body_component
 {
     b2BodyId body = b2_nullBodyId;

--- a/src/core/entity.hpp
+++ b/src/core/entity.hpp
@@ -12,35 +12,35 @@ namespace sand {
 
 using entity = apx::entity;
 
-class level;
-class contact_listener : public b2ContactListener
-{
-    level* d_level;
-
-    void begin_contact(b2Fixture* curr, b2Fixture* other);
-    void end_contact(b2Fixture* curr, b2Fixture* other);
-
-public:
-    contact_listener(level* l) : d_level{l} {}
-
-    void PreSolve(b2Contact* contact, const b2Manifold* impulse) override;
-    void BeginContact(b2Contact* contact) override;
-    void EndContact(b2Contact* contact) override;
-};
+//class level;
+//class contact_listener : public b2ContactListener
+//{
+//    level* d_level;
+//
+//    void begin_contact(b2Fixture* curr, b2Fixture* other);
+//    void end_contact(b2Fixture* curr, b2Fixture* other);
+//
+//public:
+//    contact_listener(level* l) : d_level{l} {}
+//
+//    void PreSolve(b2Contact* contact, const b2Manifold* impulse) override;
+//    void BeginContact(b2Contact* contact) override;
+//    void EndContact(b2Contact* contact) override;
+//};
 
 struct body_component
 {
-    b2Body* body = nullptr;
-    b2Fixture* body_fixture = nullptr;
+    b2BodyId body = b2_nullBodyId;
+    b2ShapeId body_fixture = b2_nullShapeId;
 };
 
 struct player_component
 {
-    b2Fixture* foot_sensor  = nullptr;
-    b2Fixture* left_sensor  = nullptr;
-    b2Fixture* right_sensor = nullptr;
+    b2ShapeId foot_sensor  = b2_nullShapeId;
+    b2ShapeId left_sensor  = b2_nullShapeId;
+    b2ShapeId right_sensor = b2_nullShapeId;
     
-    std::unordered_set<b2Fixture*> floors;
+    std::unordered_set<b2ShapeId> floors;
     int num_left_contacts  = 0;
     int num_right_contacts = 0;
 
@@ -50,7 +50,7 @@ struct player_component
 
 struct enemy_component
 {
-    b2Fixture*                 proximity_sensor = nullptr;
+    b2ShapeId                  proximity_sensor = b2_nullShapeId;
     std::unordered_set<entity> nearby_entities;
 };
 
@@ -71,8 +71,8 @@ using registry = apx::registry<
     grenade_component
 >;
 
-auto add_player(registry& entities, b2World& world, pixel_pos position) -> entity;
-auto add_enemy(registry& entities, b2World& world, pixel_pos position) -> entity;
+auto add_player(registry& entities, b2WorldId world, pixel_pos position) -> entity;
+auto add_enemy(registry& entities, b2WorldId world, pixel_pos position) -> entity;
 
 auto ecs_entity_respawn(const registry& entities, entity e) -> void;
 auto ecs_entity_centre(const registry& entities, entity e) -> glm::vec2;

--- a/src/core/entity.hpp
+++ b/src/core/entity.hpp
@@ -8,6 +8,24 @@
 #include "utility.hpp"
 #include "input.hpp"
 
+struct shape_id_hash
+{
+    auto operator()(const b2ShapeId id) const -> std::size_t
+    {
+        return std::hash<std::uint64_t>{}(std::bit_cast<std::uint64_t>(id));
+    }
+};
+
+struct shape_id_equal
+{
+    auto operator()(const b2ShapeId lhs, const b2ShapeId rhs) const -> bool
+    {
+        return lhs.generation == rhs.generation
+            && lhs.index1 == rhs.index1
+            && lhs.world0 == rhs.world0;
+    }
+};
+
 namespace sand {
 
 using entity = apx::entity;
@@ -40,7 +58,7 @@ struct player_component
     b2ShapeId left_sensor  = b2_nullShapeId;
     b2ShapeId right_sensor = b2_nullShapeId;
     
-    std::unordered_set<b2ShapeId> floors;
+    std::unordered_set<b2ShapeId, shape_id_hash, shape_id_equal> floors;
     int num_left_contacts  = 0;
     int num_right_contacts = 0;
 

--- a/src/core/update_rigid_bodies.cpp
+++ b/src/core/update_rigid_bodies.cpp
@@ -192,16 +192,6 @@ auto calc_boundary(
     return simplified;
 }
 
-auto new_body(level& l) -> b2BodyId
-{
-    b2BodyDef def = b2DefaultBodyDef();
-    def.type = b2_staticBody;
-    def.position = {0.0f, 0.0f};
-    auto body = b2CreateBody(l.physics.world, &def);
-    b2Body_SetUserData(body, (void*)(std::uintptr_t)(apx::null));
-    return body;
-}
-
 auto flood_remove(chunk_static_pixels& pixels, glm::ivec2 offset) -> void
 {
     const auto is_valid = [](const glm::ivec2 p) {
@@ -243,7 +233,11 @@ auto get_start_pixel_offset(const chunk_static_pixels& pixels) -> glm::ivec2
 
 auto create_chunk_rigid_bodies(level& l, pixel_pos top_left) -> b2BodyId
 {
-    auto body = new_body(l);
+    b2BodyDef body_def = b2DefaultBodyDef();
+    body_def.type = b2_staticBody;
+    body_def.position = {0.0f, 0.0f};
+    auto body = b2CreateBody(l.physics.world, &body_def);
+    b2Body_SetUserData(body, (void*)(std::uintptr_t)(apx::null));
     
     auto chunk_pixels = chunk_static_pixels{};
     

--- a/src/core/update_rigid_bodies.cpp
+++ b/src/core/update_rigid_bodies.cpp
@@ -194,11 +194,11 @@ auto calc_boundary(
 
 auto new_body(level& l) -> b2BodyId
 {
-    b2BodyDef def;
+    b2BodyDef def = b2DefaultBodyDef();
     def.type = b2_staticBody;
-    def.position.Set(0.0f, 0.0f);
+    def.position = {0.0f, 0.0f};
     auto body = b2CreateBody(l.physics.world, &def);
-    b2Body_SetUserData(comp.body, (void*)(std::uintptr_t)(apx::null));
+    b2Body_SetUserData(body, (void*)(std::uintptr_t)(apx::null));
     return body;
 }
 
@@ -241,7 +241,7 @@ auto get_start_pixel_offset(const chunk_static_pixels& pixels) -> glm::ivec2
     std::unreachable();
 }
 
-auto create_chunk_rigid_bodies(level& l, pixel_pos top_left) -> b2Body*
+auto create_chunk_rigid_bodies(level& l, pixel_pos top_left) -> b2BodyId
 {
     auto body = new_body(l);
     

--- a/src/core/update_rigid_bodies.cpp
+++ b/src/core/update_rigid_bodies.cpp
@@ -273,6 +273,7 @@ auto create_chunk_rigid_bodies(level& l, pixel_pos top_left) -> b2BodyId
                 points.push_back(pixel_to_physics(pos));
             }
             b2ChainDef def = b2DefaultChainDef();
+            def.enableSensorEvents = true;
             def.count = points.size();
             def.points = points.data();
             def.isLoop = true;

--- a/src/core/update_rigid_bodies.cpp
+++ b/src/core/update_rigid_bodies.cpp
@@ -237,7 +237,7 @@ auto create_chunk_rigid_bodies(level& l, pixel_pos top_left) -> b2BodyId
     body_def.type = b2_staticBody;
     body_def.position = {0.0f, 0.0f};
     auto body = b2CreateBody(l.physics.world, &body_def);
-    b2Body_SetUserData(body, (void*)(std::uintptr_t)(apx::null));
+    b2Body_SetUserData(body, to_user_data(apx::null));
     
     auto chunk_pixels = chunk_static_pixels{};
     

--- a/src/core/update_rigid_bodies.hpp
+++ b/src/core/update_rigid_bodies.hpp
@@ -3,7 +3,7 @@
 
 #include "common.hpp"
 
-class b2Body;
+struct b2BodyId;
 
 namespace sand {
 

--- a/src/core/update_rigid_bodies.hpp
+++ b/src/core/update_rigid_bodies.hpp
@@ -8,6 +8,6 @@ struct b2BodyId;
 namespace sand {
 
 class level;
-auto create_chunk_rigid_bodies(level& l, pixel_pos top_left) -> b2Body*;
+auto create_chunk_rigid_bodies(level& l, pixel_pos top_left) -> b2BodyId;
 
 }

--- a/src/core/utility.hpp
+++ b/src/core/utility.hpp
@@ -64,7 +64,7 @@ auto coin_flip() -> bool;
 auto sign_flip() -> int;
 auto random_unit() -> float; // Same as random_from_range(0.0f, 1.0f)
 
-consteval auto from_hex(int hex) -> glm::vec4
+constexpr auto from_hex(int hex) -> glm::vec4
 {
     const auto blue = static_cast<float>(hex & 0xff) / 256.0f;
     hex /= 0x100;

--- a/src/core/world.cpp
+++ b/src/core/world.cpp
@@ -676,14 +676,9 @@ static void begin_sensor_event(level& l, b2ShapeId sensor, b2ShapeId other)
 
 static void end_sensor_event(level& l, b2ShapeId sensor, b2ShapeId other)
 {
-    // Somehow explosions cause issues in debug mode due to this being an invalid. I'm not quite
-    // sure why, perhaps the out of order destruction of pixels causes rigid body refreshes
-    // that remove the bodies already referenced in events. Seems dubious, but here we are
-    if (!b2Shape_IsValid(other)) return;
-
-    const auto sensor_entity = (entity)(std::uintptr_t)b2Body_GetUserData(b2Shape_GetBody(sensor));
-    const auto other_entity = (entity)(std::uintptr_t)b2Body_GetUserData(b2Shape_GetBody(other));
+    if (!b2Shape_IsValid(sensor)) return;
     
+    const auto sensor_entity = (entity)(std::uintptr_t)b2Body_GetUserData(b2Shape_GetBody(sensor));
     if (!l.entities.valid(sensor_entity)) return;
     
     if (l.entities.has<player_component>(sensor_entity) && !b2Shape_IsSensor(other))
@@ -701,6 +696,10 @@ static void end_sensor_event(level& l, b2ShapeId sensor, b2ShapeId other)
         }
     }
     
+    // Both shapes in the end event can be invalid
+    if (!b2Shape_IsValid(other)) return;
+
+    const auto other_entity = (entity)(std::uintptr_t)b2Body_GetUserData(b2Shape_GetBody(other));
     if (l.entities.has<enemy_component>(sensor_entity) && l.entities.valid(other_entity))
     {
         auto& comp = l.entities.get<enemy_component>(sensor_entity);

--- a/src/core/world.cpp
+++ b/src/core/world.cpp
@@ -635,8 +635,8 @@ static void begin_contact(level& l, b2ShapeId curr, b2ShapeId other)
         && (!l.entities.valid(other_entity) || !l.entities.has<player_component>(other_entity)))
     {
         l.entities.mark_for_death(curr_entity);
-        //const auto pos = ecs_entity_centre(l.entities, curr_entity);
-        //apply_explosion(l.pixels, pixel_pos::from_ivec2(pos), explosion{.min_radius=5, .max_radius=10, .scorch=15});   
+        const auto pos = ecs_entity_centre(l.entities, curr_entity);
+        apply_explosion(l.pixels, pixel_pos::from_ivec2(pos), explosion{.min_radius=5, .max_radius=10, .scorch=15});   
     }
 }
 
@@ -773,6 +773,7 @@ auto level_on_update(level& l, const context& ctx) -> void
         }
     }
     l.entities.destroy_marked();
+    
 }
 
 auto level_on_event(level& l, const context& ctx, const event& ev) -> void

--- a/src/core/world.cpp
+++ b/src/core/world.cpp
@@ -624,6 +624,7 @@ level::level(i32 width, i32 height, const std::vector<pixel>& data, pixel_pos sp
 
 static void begin_contact(level& l, b2ShapeId curr, b2ShapeId other)
 {
+    std::print("start of contact\n");
     const auto curr_entity = (entity)(std::uintptr_t)b2Body_GetUserData(b2Shape_GetBody(curr));
     const auto other_entity = (entity)(std::uintptr_t)b2Body_GetUserData(b2Shape_GetBody(other));
     
@@ -634,8 +635,8 @@ static void begin_contact(level& l, b2ShapeId curr, b2ShapeId other)
         && (!l.entities.valid(other_entity) || !l.entities.has<player_component>(other_entity)))
     {
         l.entities.mark_for_death(curr_entity);
-        const auto pos = ecs_entity_centre(l.entities, curr_entity);
-        apply_explosion(l.pixels, pixel_pos::from_ivec2(pos), explosion{.min_radius=5, .max_radius=10, .scorch=15});   
+        //const auto pos = ecs_entity_centre(l.entities, curr_entity);
+        //apply_explosion(l.pixels, pixel_pos::from_ivec2(pos), explosion{.min_radius=5, .max_radius=10, .scorch=15});   
     }
 }
 

--- a/src/core/world.cpp
+++ b/src/core/world.cpp
@@ -472,7 +472,7 @@ auto update_enemy(registry& entities, entity e) -> void
                 const auto pos = physics_to_pixel(b2Body_GetPosition(curr_body_comp.body));
                 const auto self_pos = ecs_entity_centre(entities, e);
                 const auto dir = glm::normalize(pos - self_pos);
-                b2Body_ApplyLinearImpulseToCenter(body_comp.body, pixel_to_physics(0.25f * dir), true);
+                b2Body_ApplyLinearImpulseToCenter(body_comp.body, pixel_to_physics(200.0f * dir), true);
             }
         }
     }
@@ -624,7 +624,6 @@ level::level(i32 width, i32 height, const std::vector<pixel>& data, pixel_pos sp
 
 static void begin_contact(level& l, b2ShapeId curr, b2ShapeId other)
 {
-    std::print("start of contact\n");
     const auto curr_entity = (entity)(std::uintptr_t)b2Body_GetUserData(b2Shape_GetBody(curr));
     const auto other_entity = (entity)(std::uintptr_t)b2Body_GetUserData(b2Shape_GetBody(other));
     
@@ -677,6 +676,11 @@ static void begin_sensor_event(level& l, b2ShapeId sensor, b2ShapeId other)
 
 static void end_sensor_event(level& l, b2ShapeId sensor, b2ShapeId other)
 {
+    // Somehow explosions cause issues in debug mode due to this being an invalid. I'm not quite
+    // sure why, perhaps the out of order destruction of pixels causes rigid body refreshes
+    // that remove the bodies already referenced in events. Seems dubious, but here we are
+    if (!b2Shape_IsValid(other)) return;
+
     const auto sensor_entity = (entity)(std::uintptr_t)b2Body_GetUserData(b2Shape_GetBody(sensor));
     const auto other_entity = (entity)(std::uintptr_t)b2Body_GetUserData(b2Shape_GetBody(other));
     

--- a/src/core/world.cpp
+++ b/src/core/world.cpp
@@ -399,7 +399,7 @@ auto player_handle_event(level& l, const context& ctx, entity e, const event& ev
             def.position = pixel_to_physics(spawn_pot);
 
             body_comp.body = b2CreateBody(l.physics.world, &def);
-            b2Body_SetUserData(body_comp.body, (void*)(std::uintptr_t)grenade);
+            b2Body_SetUserData(body_comp.body, to_user_data(grenade));
             b2Body_SetMassData(body_comp.body, b2MassData{.mass = 10});
 
             const auto impulse = 12.0f * b2Body_GetMass(body_comp.body) * direction;
@@ -419,9 +419,6 @@ auto player_handle_event(level& l, const context& ctx, entity e, const event& ev
         }
     }
 }
-
-static_assert(sizeof(std::uintptr_t) == sizeof(entity));
-static_assert(sizeof(entity) == sizeof(void*));
 
 auto update_player(registry& entities, entity e, const input& in) -> void
 {
@@ -624,8 +621,8 @@ level::level(i32 width, i32 height, const std::vector<pixel>& data, pixel_pos sp
 
 static void begin_contact(level& l, b2ShapeId curr, b2ShapeId other)
 {
-    const auto curr_entity = (entity)(std::uintptr_t)b2Body_GetUserData(b2Shape_GetBody(curr));
-    const auto other_entity = (entity)(std::uintptr_t)b2Body_GetUserData(b2Shape_GetBody(other));
+    const auto curr_entity = from_user_data(b2Body_GetUserData(b2Shape_GetBody(curr)));
+    const auto other_entity = from_user_data(b2Body_GetUserData(b2Shape_GetBody(other)));
     
     if (!l.entities.valid(curr_entity)) return;
 
@@ -645,8 +642,8 @@ static void end_contact(level& l, b2ShapeId curr, b2ShapeId other)
 
 static void begin_sensor_event(level& l, b2ShapeId sensor, b2ShapeId other)
 {
-    const auto sensor_entity = (entity)(std::uintptr_t)b2Body_GetUserData(b2Shape_GetBody(sensor));
-    const auto other_entity = (entity)(std::uintptr_t)b2Body_GetUserData(b2Shape_GetBody(other));
+    const auto sensor_entity = from_user_data(b2Body_GetUserData(b2Shape_GetBody(sensor)));
+    const auto other_entity = from_user_data(b2Body_GetUserData(b2Shape_GetBody(other)));
     
     if (!l.entities.valid(sensor_entity)) return;
     
@@ -678,7 +675,7 @@ static void end_sensor_event(level& l, b2ShapeId sensor, b2ShapeId other)
 {
     if (!b2Shape_IsValid(sensor)) return;
     
-    const auto sensor_entity = (entity)(std::uintptr_t)b2Body_GetUserData(b2Shape_GetBody(sensor));
+    const auto sensor_entity = from_user_data(b2Body_GetUserData(b2Shape_GetBody(sensor)));
     if (!l.entities.valid(sensor_entity)) return;
     
     if (l.entities.has<player_component>(sensor_entity) && !b2Shape_IsSensor(other))
@@ -699,7 +696,7 @@ static void end_sensor_event(level& l, b2ShapeId sensor, b2ShapeId other)
     // Both shapes in the end event can be invalid
     if (!b2Shape_IsValid(other)) return;
 
-    const auto other_entity = (entity)(std::uintptr_t)b2Body_GetUserData(b2Shape_GetBody(other));
+    const auto other_entity = from_user_data(b2Body_GetUserData(b2Shape_GetBody(other)));
     if (l.entities.has<enemy_component>(sensor_entity) && l.entities.valid(other_entity))
     {
         auto& comp = l.entities.get<enemy_component>(sensor_entity);

--- a/src/core/world.cpp
+++ b/src/core/world.cpp
@@ -391,7 +391,7 @@ auto player_handle_event(level& l, const context& ctx, entity e, const event& ev
             l.entities.emplace<grenade_component>(grenade);
             
             // Create player body
-            b2BodyDef def;
+            b2BodyDef def = b2DefaultBodyDef();
             def.type = b2_dynamicBody;
             def.enableSleep = false;
             def.gravityScale = 1.0f;

--- a/src/core/world.cpp
+++ b/src/core/world.cpp
@@ -599,7 +599,6 @@ auto pixel_world::step() -> void
 
 static auto make_world(glm::vec2 gravity) -> b2WorldId
 {
-    std::print("Creating physics world\n");
     auto def = b2DefaultWorldDef();
     def.gravity = {gravity.x, gravity.y};
     return b2CreateWorld(&def);
@@ -664,6 +663,39 @@ static void begin_contact(level& l, b2ShapeId curr, b2ShapeId other)
     }
 }
 
+static void end_contact(level& l, b2ShapeId curr, b2ShapeId other)
+{
+    const auto curr_entity = (entity)(std::uintptr_t)b2Body_GetUserData(b2Shape_GetBody(curr));
+    const auto other_entity = (entity)(std::uintptr_t)b2Body_GetUserData(b2Shape_GetBody(other));
+    
+    if (!l.entities.valid(curr_entity)) return;
+    
+    if (l.entities.has<player_component>(curr_entity)
+        && !b2Shape_IsSensor(other))
+    {
+        auto& comp = l.entities.get<player_component>(curr_entity);
+        
+        if (b2Shape_IsValid(comp.foot_sensor) && B2_ID_EQUALS(curr, comp.foot_sensor)) {
+            comp.floors.erase(other);
+        }
+        if (b2Shape_IsValid(comp.left_sensor) && B2_ID_EQUALS(curr, comp.left_sensor)) {
+            --comp.num_left_contacts;
+        }
+        if (b2Shape_IsValid(comp.right_sensor) && B2_ID_EQUALS(curr, comp.right_sensor)) {
+            --comp.num_right_contacts;
+        }
+    }
+    
+    if (l.entities.has<enemy_component>(curr_entity) 
+        && l.entities.valid(other_entity))
+    {
+        auto& comp = l.entities.get<enemy_component>(curr_entity);
+        if (b2Shape_IsValid(comp.proximity_sensor) && B2_ID_EQUALS(curr, comp.proximity_sensor) && l.entities.valid(other_entity)) {
+            comp.nearby_entities.erase(other_entity);
+        }
+    }
+}
+
 auto level_on_update(level& l, const context& ctx) -> void
 {
     l.pixels.step();
@@ -688,14 +720,22 @@ auto level_on_update(level& l, const context& ctx) -> void
     b2World_Step(l.physics.world, sand::config::time_step, 4);
 
     b2ContactEvents events = b2World_GetContactEvents(l.physics.world);
+
     for (std::size_t i = 0; i != events.beginCount; ++i) {
         begin_contact(l, events.beginEvents[i].shapeIdA, events.beginEvents[i].shapeIdB);
         begin_contact(l, events.beginEvents[i].shapeIdB, events.beginEvents[i].shapeIdA);
     }
 
+    for (std::size_t i = 0; i != events.endCount; ++i) {
+        end_contact(l, events.endEvents[i].shapeIdA, events.endEvents[i].shapeIdB);
+        end_contact(l, events.endEvents[i].shapeIdB, events.endEvents[i].shapeIdA);
+    }
+
+
     for (auto e : l.entities.view<player_component>()) {
         update_player(l.entities, e, ctx.input);
     }
+
     for (auto e : l.entities.view<enemy_component>()) {
         update_enemy(l.entities, e);
     }

--- a/src/core/world.cpp
+++ b/src/core/world.cpp
@@ -408,7 +408,7 @@ auto player_handle_event(level& l, const context& ctx, entity e, const event& ev
 
             // Set up main body fixture
             {
-                b2Circle circle;
+                b2Circle circle = {};
                 circle.radius = pixel_to_physics(1.0f);
 
                 b2ShapeDef def = b2DefaultShapeDef();
@@ -599,6 +599,7 @@ auto pixel_world::step() -> void
 
 static auto make_world(glm::vec2 gravity) -> b2WorldId
 {
+    std::print("Creating physics world\n");
     auto def = b2DefaultWorldDef();
     def.gravity = {gravity.x, gravity.y};
     return b2CreateWorld(&def);

--- a/src/core/world.hpp
+++ b/src/core/world.hpp
@@ -90,6 +90,13 @@ struct physics_world
     std::unordered_map<chunk_pos, b2BodyId> chunk_bodies;
 
     physics_world(glm::vec2 gravity);
+    ~physics_world();
+
+    physics_world(const physics_world&) = delete;
+    physics_world& operator=(const physics_world&) = delete;
+
+    physics_world(physics_world&&) = default;
+    physics_world& operator=(physics_world&&) = default;
 };
 
 struct level

--- a/src/core/world.hpp
+++ b/src/core/world.hpp
@@ -86,8 +86,8 @@ public:
 
 struct physics_world
 {
-    b2World world;
-    std::unordered_map<chunk_pos, b2Body*> chunk_bodies;
+    b2WorldId world;
+    std::unordered_map<chunk_pos, b2BodyId> chunk_bodies;
 
     physics_world(glm::vec2 gravity);
 };
@@ -100,7 +100,6 @@ struct level
 
     pixel_pos        spawn_point;
     entity           player;
-    contact_listener listener;
 
     level(i32 width, i32 height, const std::vector<pixel>& pixels, pixel_pos spawn);
 };

--- a/src/editor.m.cpp
+++ b/src/editor.m.cpp
@@ -65,7 +65,7 @@ auto main() -> int
     auto accumulator     = 0.0;
     auto timer           = sand::timer{};
     auto shape_renderer  = sand::shape_renderer{};
-    auto debug_draw      = sand::physics_debug_draw{&shape_renderer};
+    //auto debug_draw      = sand::physics_debug_draw{&shape_renderer};
 
     auto update_window_half_width = 2 + sand::config::chunk_size;
     auto update_window_half_height = 2 + sand::config::chunk_size;
@@ -268,8 +268,8 @@ auto main() -> int
         shape_renderer.begin_frame(camera);
 
         if (editor.show_physics) {
-            level->physics.world.SetDebugDraw(&debug_draw);
-            level->physics.world.DebugDraw();
+            //level->physics.world.SetDebugDraw(&debug_draw);
+            //level->physics.world.DebugDraw();
         }
 
         if (editor.show_spawn) {

--- a/src/editor.m.cpp
+++ b/src/editor.m.cpp
@@ -65,7 +65,13 @@ auto main() -> int
     auto accumulator     = 0.0;
     auto timer           = sand::timer{};
     auto shape_renderer  = sand::shape_renderer{};
-    //auto debug_draw      = sand::physics_debug_draw{&shape_renderer};
+
+    b2DebugDraw debug = b2DefaultDebugDraw();
+    debug.context = static_cast<void*>(&shape_renderer);
+    debug.drawShapes = true;
+
+    debug.DrawPolygonFcn = draw_polygon;
+    debug.DrawCircleFcn = draw_circle;
 
     auto update_window_half_width = 2 + sand::config::chunk_size;
     auto update_window_half_height = 2 + sand::config::chunk_size;
@@ -268,8 +274,7 @@ auto main() -> int
         shape_renderer.begin_frame(camera);
 
         if (editor.show_physics) {
-            //level->physics.world.SetDebugDraw(&debug_draw);
-            //level->physics.world.DebugDraw();
+            b2World_Draw(level->physics.world, &debug);
         }
 
         if (editor.show_spawn) {

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -160,7 +160,7 @@ auto scene_level(sand::window& window) -> next_state
         // TODO: Replace with actual sprite data
         shape_renderer.begin_frame(ctx.camera);      
         shape_renderer.draw_circle(ecs_entity_centre(level->entities, level->player), {1.0, 1.0, 0.0, 1.0}, 3);
-        for (auto e : level->entities.all()) {
+        for (auto e : level->entities.view<body_component>()) {
             shape_renderer.draw_circle(ecs_entity_centre(level->entities, e), {0.5, 1.0, 0.5, 1.0}, 2.5);
         }
 

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -91,7 +91,6 @@ auto scene_level(sand::window& window) -> next_state
     auto accumulator     = 0.0;
     auto timer           = sand::timer{};
     auto shape_renderer  = sand::shape_renderer{};
-    //auto debug_renderer  = sand::physics_debug_draw{&shape_renderer};
     auto ui              = sand::ui_engine{};
     
     level->player = add_player(level->entities, level->physics.world, level->spawn_point);
@@ -108,6 +107,12 @@ auto scene_level(sand::window& window) -> next_state
             .world_to_screen = window.height() / 210.0f
         }
     };
+
+    b2DebugDraw debug = b2DefaultDebugDraw();
+    debug.context = static_cast<void*>(&shape_renderer);
+    debug.drawShapes = true;
+    debug.DrawPolygonFcn = draw_polygon;
+    debug.DrawCircleFcn = draw_circle;
 
     // This can be done a litle better surely.
     ctx.camera.top_left = ecs_entity_centre(level->entities, level->player) - sand::dimensions(ctx.camera) / (2.0f * ctx.camera.world_to_screen);
@@ -167,8 +172,7 @@ auto scene_level(sand::window& window) -> next_state
         const auto centre = ecs_entity_centre(level->entities, level->player);
         const auto direction = glm::normalize(mouse_pos_world_space(ctx.input, ctx.camera) - centre);
         shape_renderer.draw_line(centre, centre + 10.0f * direction, {1, 1, 1, 1}, 2);
-        //level->physics.world.SetDebugDraw(&debug_renderer);
-        //level->physics.world.DebugDraw();
+        b2World_Draw(level->physics.world, &debug);
         shape_renderer.end_frame();
         
         std::array<char, 8> buf = {};

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -111,8 +111,13 @@ auto scene_level(sand::window& window) -> next_state
     b2DebugDraw debug = b2DefaultDebugDraw();
     debug.context = static_cast<void*>(&shape_renderer);
     debug.drawShapes = true;
+    debug.drawBounds = true;
+    debug.drawContactFeatures = false;
+
     debug.DrawPolygonFcn = draw_polygon;
+    debug.DrawSolidPolygonFcn = draw_solid_polygon;
     debug.DrawCircleFcn = draw_circle;
+    debug.DrawSolidCircleFcn = draw_solid_circle;
 
     // This can be done a litle better surely.
     ctx.camera.top_left = ecs_entity_centre(level->entities, level->player) - sand::dimensions(ctx.camera) / (2.0f * ctx.camera.world_to_screen);

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -160,9 +160,9 @@ auto scene_level(sand::window& window) -> next_state
         // TODO: Replace with actual sprite data
         shape_renderer.begin_frame(ctx.camera);      
         shape_renderer.draw_circle(ecs_entity_centre(level->entities, level->player), {1.0, 1.0, 0.0, 1.0}, 3);
-        for (auto e : level->entities.view<body_component>()) {
-            shape_renderer.draw_circle(ecs_entity_centre(level->entities, e), {0.5, 1.0, 0.5, 1.0}, 2.5);
-        }
+        //for (auto e : level->entities.view<body_component>()) {
+        //    shape_renderer.draw_circle(ecs_entity_centre(level->entities, e), {0.5, 1.0, 0.5, 1.0}, 2.5);
+        //}
 
         const auto centre = ecs_entity_centre(level->entities, level->player);
         const auto direction = glm::normalize(mouse_pos_world_space(ctx.input, ctx.camera) - centre);

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -91,7 +91,7 @@ auto scene_level(sand::window& window) -> next_state
     auto accumulator     = 0.0;
     auto timer           = sand::timer{};
     auto shape_renderer  = sand::shape_renderer{};
-    auto debug_renderer  = sand::physics_debug_draw{&shape_renderer};
+    //auto debug_renderer  = sand::physics_debug_draw{&shape_renderer};
     auto ui              = sand::ui_engine{};
     
     level->player = add_player(level->entities, level->physics.world, level->spawn_point);
@@ -167,8 +167,8 @@ auto scene_level(sand::window& window) -> next_state
         const auto centre = ecs_entity_centre(level->entities, level->player);
         const auto direction = glm::normalize(mouse_pos_world_space(ctx.input, ctx.camera) - centre);
         shape_renderer.draw_line(centre, centre + 10.0f * direction, {1, 1, 1, 1}, 2);
-        level->physics.world.SetDebugDraw(&debug_renderer);
-        level->physics.world.DebugDraw();
+        //level->physics.world.SetDebugDraw(&debug_renderer);
+        //level->physics.world.DebugDraw();
         shape_renderer.end_frame();
         
         std::array<char, 8> buf = {};

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -111,13 +111,14 @@ auto scene_level(sand::window& window) -> next_state
     b2DebugDraw debug = b2DefaultDebugDraw();
     debug.context = static_cast<void*>(&shape_renderer);
     debug.drawShapes = true;
-    debug.drawBounds = true;
+    debug.drawBounds = false;
     debug.drawContactFeatures = false;
 
     debug.DrawPolygonFcn = draw_polygon;
     debug.DrawSolidPolygonFcn = draw_solid_polygon;
     debug.DrawCircleFcn = draw_circle;
     debug.DrawSolidCircleFcn = draw_solid_circle;
+    debug.DrawSegmentFcn = draw_segment;
 
     // This can be done a litle better surely.
     ctx.camera.top_left = ecs_entity_centre(level->entities, level->player) - sand::dimensions(ctx.camera) / (2.0f * ctx.camera.world_to_screen);

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -160,9 +160,9 @@ auto scene_level(sand::window& window) -> next_state
         // TODO: Replace with actual sprite data
         shape_renderer.begin_frame(ctx.camera);      
         shape_renderer.draw_circle(ecs_entity_centre(level->entities, level->player), {1.0, 1.0, 0.0, 1.0}, 3);
-        //for (auto e : level->entities.view<body_component>()) {
-        //    shape_renderer.draw_circle(ecs_entity_centre(level->entities, e), {0.5, 1.0, 0.5, 1.0}, 2.5);
-        //}
+        for (auto e : level->entities.view<body_component>()) {
+            shape_renderer.draw_circle(ecs_entity_centre(level->entities, e), {0.5, 1.0, 0.5, 1.0}, 2.5);
+        }
 
         const auto centre = ecs_entity_centre(level->entities, level->player);
         const auto direction = glm::normalize(mouse_pos_world_space(ctx.input, ctx.camera) - centre);


### PR DESCRIPTION
* Update Box2D to the new API.
* Overall, despite being C, this is a far nicer API than before. The events for collisions rather than callbacks is far cleaner and fits with my mental model nicer, and moves more of the update code into a single place.
* Fixed a bug with the marked entities; storing them in a vector allows for duplicates, and an assertion would fail when trying to double delete. These are stored in a set now.
* Made `from_hex` `constexpr` instead of `consteval`, as it is the natural function to use for converting colour values from the new Box2D.