### PR TITLE
Simplify Level Struct

### DIFF
--- a/src/core/apecs.hpp
+++ b/src/core/apecs.hpp
@@ -244,6 +244,14 @@ private:
     }
 
 public:
+    registry() = default;
+    
+    registry(const registry&) = delete;
+    registry& operator=(const registry&) = delete;
+
+    registry(registry&&) = default;
+    registry& operator=(registry&&) = default;
+
     ~registry()
     {
         clear();

--- a/src/core/serialisation.cpp
+++ b/src/core/serialisation.cpp
@@ -16,8 +16,8 @@ auto new_level(int chunks_width, int chunks_height) -> level
     const auto width = sand::config::chunk_size * chunks_width;
     const auto height = sand::config::chunk_size * chunks_height;
     return {
-        pixel_world{width, height, std::vector<sand::pixel>(width * height, sand::pixel::air())},
-        physics_world{config::gravity},
+        pixel_world{width, height},
+        physics_world{},
         registry{},
         pixel_pos{width/2, height/2},
         apx::null
@@ -50,7 +50,7 @@ auto load_level(const std::string& file_path) -> level
     // TODO: Store the sizes as u32's in the file
     return {
         pixel_world{static_cast<i32>(save.width), static_cast<i32>(save.height), save.pixels},
-        physics_world{config::gravity},
+        physics_world{},
         registry{},
         pixel_pos{save.spawn_point.x, save.spawn_point.y},
         apx::null

--- a/src/core/serialisation.cpp
+++ b/src/core/serialisation.cpp
@@ -11,16 +11,17 @@
 
 namespace sand {
 
-auto new_level(int chunks_width, int chunks_height) -> std::unique_ptr<sand::level>
+auto new_level(int chunks_width, int chunks_height) -> level
 {
     const auto width = sand::config::chunk_size * chunks_width;
     const auto height = sand::config::chunk_size * chunks_height;
-    return std::make_unique<sand::level>(
-        width,
-        height,
-        std::vector<sand::pixel>(width * height, sand::pixel::air()),
-        pixel_pos{width/2, height/2}
-    );
+    return {
+        pixel_world{width, height, std::vector<sand::pixel>(width * height, sand::pixel::air())},
+        physics_world{config::gravity},
+        registry{},
+        pixel_pos{width/2, height/2},
+        apx::null
+    };
 }
 
 auto save_level(const std::string& file_path, const sand::level& w) -> void
@@ -38,7 +39,7 @@ auto save_level(const std::string& file_path, const sand::level& w) -> void
     archive(save);
 }
 
-auto load_level(const std::string& file_path) -> std::unique_ptr<sand::level>
+auto load_level(const std::string& file_path) -> level
 {
     auto file = std::ifstream{file_path, std::ios::binary};
     auto archive = cereal::BinaryInputArchive{file};
@@ -47,9 +48,13 @@ auto load_level(const std::string& file_path) -> std::unique_ptr<sand::level>
     archive(save);
 
     // TODO: Store the sizes as u32's in the file
-    const auto spawn = pixel_pos{save.spawn_point.x, save.spawn_point.y};
-    auto w = std::make_unique<sand::level>(static_cast<i32>(save.width), static_cast<i32>(save.height), save.pixels, spawn);
-    return w;
+    return {
+        pixel_world{static_cast<i32>(save.width), static_cast<i32>(save.height), save.pixels},
+        physics_world{config::gravity},
+        registry{},
+        pixel_pos{save.spawn_point.x, save.spawn_point.y},
+        apx::null
+    };
 }
 
 }

--- a/src/core/serialisation.hpp
+++ b/src/core/serialisation.hpp
@@ -6,8 +6,8 @@
 
 namespace sand {
 
-auto new_level(i32 chunks_width, i32 chunks_height) -> std::unique_ptr<sand::level>;
+auto new_level(i32 chunks_width, i32 chunks_height) -> level;
 auto save_level(const std::string& file_path, const sand::level& w) -> void;
-auto load_level(const std::string& file_path) -> std::unique_ptr<sand::level>;
+auto load_level(const std::string& file_path) -> level;
 
 }

--- a/src/core/world.cpp
+++ b/src/core/world.cpp
@@ -612,13 +612,6 @@ physics_world::~physics_world()
     b2DestroyWorld(world);
 }
 
-level::level(i32 width, i32 height, const std::vector<pixel>& data, pixel_pos spawn)
-    : pixels{width, height, data}
-    , physics{config::gravity}
-    , spawn_point{spawn}
-{
-}
-
 static void begin_contact(level& l, b2ShapeId curr, b2ShapeId other)
 {
     const auto curr_entity = from_user_data(b2Body_GetUserData(b2Shape_GetBody(curr)));

--- a/src/core/world.hpp
+++ b/src/core/world.hpp
@@ -107,8 +107,6 @@ struct level
 
     pixel_pos        spawn_point;
     entity           player;
-
-    level(i32 width, i32 height, const std::vector<pixel>& pixels, pixel_pos spawn);
 };
 
 auto level_on_update(level& l, const context& ctx) -> void;

--- a/src/core/world.hpp
+++ b/src/core/world.hpp
@@ -101,12 +101,12 @@ struct physics_world
 
 struct level
 {
-    pixel_world      pixels;
-    physics_world    physics;
-    registry         entities;
+    pixel_world   pixels;
+    physics_world physics;
+    registry      entities;
 
-    pixel_pos        spawn_point;
-    entity           player;
+    pixel_pos     spawn_point;
+    entity        player;
 };
 
 auto level_on_update(level& l, const context& ctx) -> void;

--- a/src/core/world.hpp
+++ b/src/core/world.hpp
@@ -50,6 +50,9 @@ public:
         const auto height_chunks = height / config::chunk_size;
         d_chunks.resize(width_chunks * height_chunks);
     }
+    pixel_world(i32 width, i32 height)
+        : pixel_world(width, height, std::vector<sand::pixel>(width * height, sand::pixel::air()))
+    {}
     
     auto step() -> void;
 
@@ -89,7 +92,7 @@ struct physics_world
     b2WorldId world;
     std::unordered_map<chunk_pos, b2BodyId> chunk_bodies;
 
-    physics_world(glm::vec2 gravity);
+    physics_world(glm::vec2 gravity = config::gravity);
     ~physics_world();
 
     physics_world(const physics_world&) = delete;

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -94,8 +94,8 @@ auto scene_level(sand::window& window) -> next_state
     auto ui              = sand::ui_engine{};
     
     level.player = add_player(level.entities, level.physics.world, level.spawn_point);
-    const auto player_pos = glm::ivec2{ecs_entity_centre(level.entities, level.player) + glm::vec2{200, 0}};
-    add_enemy(level.entities, level.physics.world, pixel_pos::from_ivec2(player_pos));
+    const auto enemy_pos = glm::ivec2{ecs_entity_centre(level.entities, level.player) + glm::vec2{200, 0}};
+    add_enemy(level.entities, level.physics.world, pixel_pos::from_ivec2(enemy_pos));
     
     auto ctx = context{
         .window=&window,


### PR DESCRIPTION
* Now that there's no coupling between the pixel world and the physics world, the `level` class no longer needs a constructor.
* Make the `registry` class non-copyable, since copying all entities is almost certainly always a mistake.
* The `level` class also no longer needs to be stored in a `unique_ptr`, so can just live on the stack now.